### PR TITLE
Render passes

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,0 +1,86 @@
+<html>
+    <head>
+        <title></title>
+
+        <link rel="stylesheet" type="text/css" href="style.css">
+    </head>
+    <body>
+        <canvas id="gl-canvas" width="800" height="800">
+            Oops ... your browser doesn't support the HTML5 canvas element
+        </canvas>
+
+        <script src="../src/vendor/stats.js"></script>
+        <script src="../src/vendor/ccapture/CCapture.all.min.js"></script>
+        <script type="module">
+
+            // import the `Points` class
+
+            import Points, {RenderPass} from '../src/absulit.points.module.js';
+            import { fnusin } from '../src/core/defaultFunctions.js';
+
+            // reference the canvas in the constructor
+            const points = new Points('gl-canvas');
+
+            // create your render pass with three shaders as follow
+            const renderPasses = [
+                new RenderPass(/*wgsl*/`
+                @vertex
+                fn main(
+                    @location(0) position: vec4<f32>,
+                    @location(1) color: vec4<f32>,
+                    @location(2) uv: vec2<f32>,
+                    @builtin(vertex_index) vertexIndex: u32
+                ) -> Fragment {
+
+                    return defaultVertexBody(position, color, uv);
+                }`,
+                /*wgsl*/`
+
+                @compute @workgroup_size(8,8,1)
+                fn main(
+                    @builtin(global_invocation_id) GlobalId: vec3<u32>,
+                    @builtin(workgroup_id) WorkGroupID: vec3<u32>,
+                    @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
+                ) {
+                    let time = params.time;
+                }
+                `,
+                /*wgsl*/`
+                ${fnusin}
+                @fragment
+                fn main(
+                    @location(0) color: vec4<f32>,
+                    @location(1) uv: vec2<f32>,
+                    @location(2) ratio: vec2<f32>,  // relation between params.screenWidth and params.screenHeight
+                    @location(3) uvr: vec2<f32>,    // uv with aspect ratio corrected
+                    @location(4) mouse: vec2<f32>,
+                    @builtin(position) position: vec4<f32>
+                ) -> @location(0) vec4<f32> {
+
+                    let cellSize = 20. + 10. * fnusin(1.);
+                    let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
+                    let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );
+                    let c = fnusin(uvr.x * uvr.y * 10.);
+                    let d = distance(a,b);
+                    let f = d * uvr.x * uvr.y;
+                    let finalColor:vec4<f32> = vec4(a*d,f*c*a,f, 1.);
+
+                    return finalColor;
+                }
+                `
+                )
+            ];
+
+            // call the POINTS init method and then the update method
+            await points.init(renderPasses);
+            update();
+
+            // call `points.update()` methods to render a new frame
+            function update() {
+                points.update();
+                requestAnimationFrame(update);
+            }
+
+        </script>
+    </body>
+</html>

--- a/examples/bloom1/compute.js
+++ b/examples/bloom1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/bloom1/index.js
+++ b/examples/bloom1/index.js
@@ -1,16 +1,16 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
+
 const bloom1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler');
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/circleblur/compute.js
+++ b/examples/circleblur/compute.js
@@ -6,14 +6,6 @@ struct Variables{
     testValue: f32
 }
 
-struct Chemical{
-    a: f32,
-    b: f32
-}
-
-struct Particles{
-    chemicals: array<Chemical>
-}
 
 ${clearMix}
 
@@ -29,11 +21,6 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
-    //let dims : vec2<u32> = textureDimensions(feedbackTexture, 0);
-    //let rgb = textureSampleLevel(feedbackTexture, feedbackSampler, (vec2<f32>(0) + vec2<f32>(0.25, 0.25)) / vec2<f32>(dims),0.0).rgb;
-    //--------------------------------------------------------------
 
     let filterDim = 128u;
     let blockDim = 128u;
@@ -47,55 +34,9 @@ fn main(
         LocalInvocationID.xy * vec2<u32>(4u, 1u)
     ) - vec2<i32>(i32(filterOffset), 0);
 
-    // for (var r : u32 = 0u; r < 4u; r = r + 1u) {
-    //     for (var c : u32 = 0u; c < 4u; c = c + 1u) {
-    //         var loadIndex = baseIndex + vec2<i32>(i32(c), i32(r));
-    //         if (flipValue != 0u) {
-    //             loadIndex = loadIndex.yx;
-    //         }
-
-    //         tile[r][4u * LocalInvocationID.x + c] = textureSampleLevel(
-    //             feedbackTexture,
-    //             feedbackSampler,
-    //             (vec2<f32>(loadIndex) + vec2<f32>(0.25, 0.25)) / vec2<f32>(dims), 
-    //             0.0
-    //         ).rgb;
-    //     }
-    // }
-
-    // workgroupBarrier();
-
-    // for (var r : u32 = 0u; r < 4u; r = r + 1u) {
-    //     for (var c : u32 = 0u; c < 4u; c = c + 1u) {
-    //         var writeIndex = baseIndex + vec2<i32>(i32(c), i32(r));
-    //         if (flipValue != 0u) {
-    //             writeIndex = writeIndex.yx;
-    //         }
-
-    //         let center : u32 = 4u * LocalInvocationID.x + c;
-    //         if (center >= filterOffset &&
-    //             center < 128u - filterOffset &&
-    //             all(writeIndex < vec2<i32>(dims))) {
-    //             var acc : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
-    //             for (var f : u32 = 0u; f < filterDim; f = f + 1u) {
-    //                 var i : u32 = center + f - filterOffset;
-    //                 acc = acc + (1.0 / f32(filterDim)) * tile[r][i];
-    //             }
-    //             textureStore(outputTex, writeIndex, vec4<f32>(acc, 1.0));
-    //         }
-    //     }
-    // }
-
-    let rgb = textureSampleLevel(feedbackTexture,feedbackSampler, vec2<f32>(0,0),  0.0).rgba;
-
-    // textureStore(outputTex, vec2<i32>(0,0), vec4<f32>(1,1,0, 1.0));
-    // textureStore(outputTex, vec2<i32>(1,0), vec4<f32>(1,0,0, 1.0));
-    // textureStore(outputTex, vec2<i32>(799,0), vec4<f32>(1,0,0, 1.0));
-
-
+    // ----------------------------------------------
     let numColumns:f32 = f32(dims.x);
     let numRows:f32 = f32(dims.y);
-    //let constant = u32(numColumns) / 93u;
 
     let numColumnsPiece:i32 = i32(numColumns / f32(workgroupSize));
     let numRowsPiece:i32 = i32(numRows / f32(workgroupSize));
@@ -110,21 +51,13 @@ fn main(
             let uy = u32(y);
             let ny = y / numRows;
 
-            //let index:f32 = y + (x * screenSize.numColumns);
-            var rgba = textureSampleLevel(feedbackTexture,feedbackSampler, vec2<f32>(x,y),  0.0).rgba;
+            var rgba = textureSampleLevel(feedbackTexture,feedbackSampler, vec2<f32>(x,y),  0.0);
 
-            //rgba += vec4<f32>(1.,0.,0.,.5);
             rgba = clearMix(rgba, 1.01) + vec4<f32>(1.,0.,0., .5);
 
             textureStore(outputTex, vec2<u32>(ux,uy), rgba);
-
         }
-
-
     }
-
-
-
 }
 `;
 

--- a/examples/circleblur/frag.js
+++ b/examples/circleblur/frag.js
@@ -22,11 +22,10 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    //let texColor = textureSample(myTexture, mySampler, uv * 1.0 + .1 * fnusin(2));
     let startPosition = vec2(0.);
-    let texColor = texturePosition(feedbackTexture, feedbackSampler, startPosition, uv, false);
-    let texColor2 = texturePosition(feedbackTexture, feedbackSampler, startPosition, uv + vec2(-.001,1), false);
-    let texColor3 = texturePosition(feedbackTexture, feedbackSampler, startPosition, uv + vec2(.001,1), false);
+    let texColor = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr, false);
+    let texColor2 = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr + vec2(-.001,1), false);
+    let texColor3 = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr + vec2(.001,1), false);
 
     let texColorCompute = texturePosition(computeTexture, feedbackSampler, startPosition, uv, false);
 
@@ -40,21 +39,10 @@ fn main(
     let decayG =  texColor.g * .9;
     let decayB =  texColor.b * .9 * texColor3.b;
     let decayA =  texColor.a * .9;
-    //var finalColor:vec4<f32> = vec4(uv.x * c + decayR, uv.y * c + decayR, c + decayB, 1);
+
     var finalColor:vec4<f32> = vec4(uv.x * c, uv.y * c, c, 1);
     finalColor += vec4(decayR, decayG, decayB, 1);
     finalColor += texColorCompute;
-
-    // let cellSize = 20. + 10. * fnusin(1.);
-    // let a = sin(uv.x  * cellSize) * sin(uv.y * cellSize);
-    // let b = sin(uv.x * uv.y * 10. * 9.1 * .25 );
-    // let cc = fnusin(uv.x * uv.y * 10.);
-    // let dd = distance(a,b);
-    // let f = dd * uv.x * uv.y;
-    // finalColor = vec4(a*dd + decayR,f*cc*a+decayG,f+decayB, a*dd + decayA);
-    // finalColor += vec4(decayR, decayG, decayB, decayA) * .1;
-
-
 
     return finalColor;
 }

--- a/examples/data1/compute.js
+++ b/examples/data1/compute.js
@@ -19,8 +19,6 @@ fn main(
         return;
     }
 
-    let time = params.time;
-
     resultMatrix.size = vec2(firstMatrix.size.x, secondMatrix.size.y);
 
     let resultCell = vec2(GlobalId.x, GlobalId.y);

--- a/examples/data1/frag.js
+++ b/examples/data1/frag.js
@@ -1,12 +1,18 @@
 const frag = /*wgsl*/`
 
+struct Matrix {
+    size : vec2<f32>,
+    numbers: array<f32>,
+}
+
+
 @fragment
 fn main(
         @location(0) color: vec4<f32>,
         @location(1) uv: vec2<f32>
     ) -> @location(0) vec4<f32> {
 
-    let time = params.time;
+    // frag code
 
     return color;
 }

--- a/examples/data1/index.js
+++ b/examples/data1/index.js
@@ -18,7 +18,7 @@ const data1 = {
             5, 6, 7, 8
         ];
 
-        points.addStorageMap('firstMatrix', firstMatrix, 'Matrix', ShaderType.COMPUTE);
+        points.addStorageMap('firstMatrix', firstMatrix, 'Matrix');
 
         const secondMatrix = [
             4 /* rows */, 2 /* columns */,
@@ -28,10 +28,10 @@ const data1 = {
             7, 8
         ];
 
-        points.addStorageMap('secondMatrix', secondMatrix, 'Matrix', ShaderType.COMPUTE);
+        points.addStorageMap('secondMatrix', secondMatrix, 'Matrix');
 
         let resultMatrixBufferSize = Float32Array.BYTES_PER_ELEMENT * (2 + firstMatrix[0] * secondMatrix[1]);
-        points.addStorage('resultMatrix', 1, 'Matrix', resultMatrixBufferSize, ShaderType.COMPUTE, true);
+        points.addStorage('resultMatrix', 1, 'Matrix', resultMatrixBufferSize, true);
     },
     update: async points => {
 

--- a/examples/demo_6/compute.js
+++ b/examples/demo_6/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/demo_6/frag.js
+++ b/examples/demo_6/frag.js
@@ -2,11 +2,9 @@ const frag = /*wgsl*/`
 
 @fragment
 fn main(
-        @location(0) color: vec4<f32>, 
-        @location(1) uv: vec2<f32>
-    ) -> @location(0) vec4<f32> {
-
-    let time = params.time;
+    @location(0) color: vec4<f32>,
+    @location(1) uv: vec2<f32>
+) -> @location(0) vec4<f32> {
 
     return color;
 }

--- a/examples/dithering1/compute.js
+++ b/examples/dithering1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
+    // compute code
 }
 `;
 

--- a/examples/dithering1/index.js
+++ b/examples/dithering1/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const dithering1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/dithering2/compute.js
+++ b/examples/dithering2/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
+    // compute code
 }
 `;
 

--- a/examples/dithering2/index.js
+++ b/examples/dithering2/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const dithering2 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/dithering3/compute.js
+++ b/examples/dithering3/compute.js
@@ -16,12 +16,6 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
-
-
-
-
-
     //--------------------------------------------------
     let dims = textureDimensions(image);
 

--- a/examples/dithering3/index.js
+++ b/examples/dithering3/index.js
@@ -7,15 +7,15 @@ const dithering3 = {
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.COMPUTE);
-        // await points.addTextureWebcam('image', ShaderType.COMPUTE);
-        // await points.addTextureImage('image', './../img/angel_600x600.jpg', ShaderType.COMPUTE);
-        // await points.addTextureImage('image', './../img/gratia_800x800.jpg', ShaderType.COMPUTE);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.COMPUTE);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        // await points.addTextureWebcam('image');
+        // await points.addTextureImage('image', './../img/angel_600x600.jpg');
+        // await points.addTextureImage('image', './../img/gratia_800x800.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
         points.addBindingTexture('outputTex', 'computeTexture');
-        points.addLayers(2, ShaderType.COMPUTE);
+        points.addLayers(2);
         points.addStorage('variables', 1, 'Variable', 2, ShaderType.COMPUTE);
     },
     update: points => {

--- a/examples/dithering4/compute.js
+++ b/examples/dithering4/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
+    // compute code
 }
 `;
 

--- a/examples/dithering4/index.js
+++ b/examples/dithering4/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const dithering4 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/imagescale1/index.js
+++ b/examples/imagescale1/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const imagescale1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        await points.addTextureImage('image1', './../img/gratia_800x800.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image2', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image3', './../img/unnamed_horror_100x100.png', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        await points.addTextureImage('image1', './../img/gratia_800x800.jpg');
+        await points.addTextureImage('image2', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image3', './../img/unnamed_horror_100x100.png');
     },
     update: points => {
 

--- a/examples/imagetexture1/compute.js
+++ b/examples/imagetexture1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // let time = params.time;
 }
 `;
 

--- a/examples/imagetexture1/index.js
+++ b/examples/imagetexture1/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const imagetexture1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/imagetexture2/compute.js
+++ b/examples/imagetexture2/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/imagetexture2/index.js
+++ b/examples/imagetexture2/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const imagetexture2 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/imagetexture3/compute.js
+++ b/examples/imagetexture3/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/imagetexture3/frag.js
+++ b/examples/imagetexture3/frag.js
@@ -1,19 +1,11 @@
-import { brightness, fnusin, fusin, polar, sdfCircle, sdfLine, sdfSegment } from '../../src/core/defaultFunctions.js';
-import { snoise } from '../../src/core/noise2d.js';
+import { brightness, fnusin } from '../../src/core/defaultFunctions.js';
 import { texturePosition } from '../../src/core/image.js';
 
 const frag = /*wgsl*/`
 
 ${fnusin}
-${fusin}
-${sdfCircle}
-${sdfSegment}
-${sdfLine}
 ${brightness}
-${polar}
-${snoise}
 ${texturePosition}
-
 
 @fragment
 fn main(
@@ -25,23 +17,12 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    // let n1 = snoise(uv + 2 * fnusin(1));
-
-    // let dims: vec2<u32> = textureDimensions(image, 0);
-    // var dimsRatio = f32(dims.x) / f32(dims.y);
-
-    // let imageUV = uv * vec2(1,-1 * dimsRatio) * ratio.y / params.sliderA;
-    //let oldKingUVClamp = uv * vec2(1,1 * dimsRatio) * ratio.x;
     let lines = sin( uv.x*(uv.x + 3 * fnusin(1))  ) ;
     let startPosition = vec2(0.);
     let rgbaImage = texturePosition(image, feedbackSampler, startPosition, uvr * lines / params.sliderA, false); //* .998046;
 
     let b = brightness(rgbaImage);
-    let d = distance(uv, rgbaImage.xy);
 
-    //let finalColor:vec4<f32> = mix(  vec4(1,0,0,1)   , vec4(1,1,0,1) , b) * fnusin(d);
-    //let finalColor:vec4<f32> = rgbaImage;
-    //let finalColor:vec4<f32> = vec4(b);
     let finalColor:vec4<f32> = vec4(b);
 
 

--- a/examples/imagetexture3/index.js
+++ b/examples/imagetexture3/index.js
@@ -1,16 +1,15 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const imagetexture3 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('oldking', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('oldking', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/imagetexture4/compute.js
+++ b/examples/imagetexture4/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/imagetexture4/frag.js
+++ b/examples/imagetexture4/frag.js
@@ -37,7 +37,7 @@ fn main(
     //let imageUV = uv * vec2(1,-1 * dimsRatio) * ratio.x / params.sliderA;
     //let oldKingUVClamp = uv * vec2(1,1 * dimsRatio) * ratio.x;
     let startPosition = vec2(.0);
-    let rgbaImage = texturePosition(image, feedbackSampler, startPosition, uvr * params.sliderA, false); //* .998046;
+    let rgbaImage = texturePosition(image, imageSampler, startPosition, uvr * params.sliderA, false); //* .998046;
 
 
     //let finalColor:vec4<f32> = vec4(brightness(rgbaImage));

--- a/examples/imagetexture4/index.js
+++ b/examples/imagetexture4/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const imagetexture4 = {
     vert,
     compute,
@@ -19,10 +18,10 @@ const imagetexture4 = {
             //maxAnisotropy: 10,
         }
 
-        points.addSampler('feedbackSampler', descriptor, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('imageSampler', descriptor);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        // await points.addTextureImage('image', './../img/absulit_800x800.jpg');
     },
     update: points => {
 

--- a/examples/layers1/compute.js
+++ b/examples/layers1/compute.js
@@ -8,8 +8,8 @@ fn main(
 ) {
     let time = params.time;
 
-    _ = points[0];
-    _ = layers[0];
+    // _ = points[0];
+    // _ = layers[0];
 }
 `;
 

--- a/examples/layers1/compute.js
+++ b/examples/layers1/compute.js
@@ -6,10 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
-    // _ = points[0];
-    // _ = layers[0];
+    // compute code
 }
 `;
 

--- a/examples/layers1/frag.js
+++ b/examples/layers1/frag.js
@@ -14,9 +14,6 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    // _ = points[0];
-    //_ = layers.layer0[0];
-
     let cellSize = 20. + 10. * fnusin(1.);
     let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
     let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );

--- a/examples/layers1/frag.js
+++ b/examples/layers1/frag.js
@@ -14,7 +14,7 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    _ = points[0];
+    // _ = points[0];
     //_ = layers.layer0[0];
 
     let cellSize = 20. + 10. * fnusin(1.);

--- a/examples/layers1/index.js
+++ b/examples/layers1/index.js
@@ -9,7 +9,7 @@ const layers1 = {
     init: async points => {
         const numPoints = 800*800;
         points.addUniform('numPoints', numPoints);
-        points.addStorage('points', numPoints, 'vec4<f32>', 4);
+        // points.addStorage('points', numPoints, 'vec4<f32>', 4);
         points.addLayers(2, ShaderType.COMPUTE);
     },
     update: points => {

--- a/examples/layers1/index.js
+++ b/examples/layers1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const layers1 = {
     vert,
     compute,
@@ -10,7 +9,7 @@ const layers1 = {
         const numPoints = 800*800;
         points.addUniform('numPoints', numPoints);
         // points.addStorage('points', numPoints, 'vec4<f32>', 4);
-        points.addLayers(2, ShaderType.COMPUTE);
+        points.addLayers(2);
     },
     update: points => {
 

--- a/examples/main.js
+++ b/examples/main.js
@@ -79,6 +79,7 @@ const shaderProjects = [
     { name: 'Random 1', path: './random1/index.js' },
     { name: 'Random 2 (⚠ SLOW)', path: './random2/index.js' },
     { name: 'Random 3', path: './random3/index.js' },
+    { name: 'Render Passes 1', path: './renderpasses1/index.js' },
     { name: 'Shapes 1', path: './shapes1/index.js' },
     { name: 'Shapes 2', path: './shapes2/index.js' },
     { name: 'Spritesheet 1', path: './spritesheet1/index.js' },
@@ -171,7 +172,7 @@ async function init() {
 
 
     await shaders.init(points);
-    let renderPasses = [new RenderPass(shaders.vert, shaders.compute, shaders.frag)]
+    let renderPasses = shaders.renderPasses || [new RenderPass(shaders.vert, shaders.compute, shaders.frag)]
     await points.init(renderPasses);
     points.fitWindow = isFitWindow;
 

--- a/examples/main.js
+++ b/examples/main.js
@@ -1,6 +1,6 @@
 'use strict';
 import * as dat from './../src/vendor/datgui/dat.gui.module.js';
-import Points, { ShaderType } from '../src/absulit.points.module.js';
+import Points, { RenderPass, ShaderType } from '../src/absulit.points.module.js';
 
 /***************/
 const stats = new Stats();
@@ -171,13 +171,13 @@ async function init() {
 
 
     await shaders.init(points);
-    await points.init(shaders.vert, shaders.compute, shaders.frag);
+    let renderPasses = [new RenderPass(shaders.vert, shaders.compute, shaders.frag)]
+    await points.init(renderPasses);
     points.fitWindow = isFitWindow;
 
     update();
-    
+
     shaders.read && await shaders.read(points);
-    
 }
 
 function update() {

--- a/examples/mesh1/compute.js
+++ b/examples/mesh1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/mouse1/compute.js
+++ b/examples/mouse1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/mouse1/frag.js
+++ b/examples/mouse1/frag.js
@@ -1,21 +1,10 @@
-import { brightness, fnusin, fusin, polar, sdfCircle, sdfLine, sdfSegment } from '../../src/core/defaultFunctions.js';
-import { snoise } from '../../src/core/noise2d.js';
-import { PI } from '../../src/core/defaultConstants.js';
-import { texturePosition } from '../../src/core/image.js';
+import { sdfLine, sdfSegment } from '../../src/core/defaultFunctions.js';
 import { showDebugCross, showDebugFrame } from '../../src/core/debug.js';
 
 const frag = /*wgsl*/`
 
-${fnusin}
-${fusin}
-${sdfCircle}
 ${sdfSegment}
 ${sdfLine}
-${brightness}
-${polar}
-${snoise}
-${PI}
-${texturePosition}
 ${showDebugCross}
 ${showDebugFrame}
 
@@ -30,23 +19,13 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    let n1 = snoise(uv * fnusin(1));
-
-    // let dims: vec2<u32> = textureDimensions(image, 0);
-    // var dimsRatio = f32(dims.x) / f32(dims.y);
-
-    //let imageUV = uv * vec2(1,-1 * dimsRatio) * ratio.x / params.sliderA;
-    //let oldKingUVClamp = uv * vec2(1,1 * dimsRatio) * ratio.x;
     let startPosition = mouse * ratio;//vec2(.0);
 
     let positionCross = showDebugCross(startPosition, vec4(1,0,0,1), uv * ratio);
 
     let frame = showDebugFrame(vec4(1,0,0,1), uvr);
 
-    //let finalColor:vec4<f32> = vec4(brightness(rgbaImage));
     let finalColor:vec4<f32> = positionCross + frame;
-
-
 
     return finalColor;
 }

--- a/examples/mouse1/index.js
+++ b/examples/mouse1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const mouse1 = {
     vert,
     compute,

--- a/examples/mouseclickscroll1/compute.js
+++ b/examples/mouseclickscroll1/compute.js
@@ -1,12 +1,18 @@
 const compute = /*wgsl*/`
 
+struct Variable{
+    init: f32,
+    circleRadius:f32,
+    circlePosition:vec2<f32>
+}
+
 @compute @workgroup_size(8,8,1)
 fn main(
     @builtin(global_invocation_id) GlobalId: vec3<u32>,
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // let time = params.time;
 }
 `;
 

--- a/examples/mouseclickscroll1/compute.js
+++ b/examples/mouseclickscroll1/compute.js
@@ -12,7 +12,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    // let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/mouseclickscroll1/frag.js
+++ b/examples/mouseclickscroll1/frag.js
@@ -1,4 +1,4 @@
-import { fnusin, sdfCircle } from "../../src/core/defaultFunctions.js";
+import { sdfCircle } from "../../src/core/defaultFunctions.js";
 import { GREEN, RED } from './../../src/core/color.js';
 
 const frag = /*wgsl*/`
@@ -9,7 +9,6 @@ struct Variable{
     circlePosition:vec2<f32>
 }
 
-${fnusin}
 ${sdfCircle}
 ${RED + GREEN}
 

--- a/examples/mouseclickscroll1/index.js
+++ b/examples/mouseclickscroll1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 
 const mouseclickscroll1 = {
     vert,

--- a/examples/mouseclickscroll1/index.js
+++ b/examples/mouseclickscroll1/index.js
@@ -8,7 +8,7 @@ const mouseclickscroll1 = {
     compute,
     frag,
     init: async points => {
-        points.addStorage('variables', 1, 'Variable', 4, ShaderType.FRAGMENT);
+        points.addStorage('variables', 1, 'Variable', 4);
     },
     update: points => {
 

--- a/examples/mouseclickscroll1/vert.js
+++ b/examples/mouseclickscroll1/vert.js
@@ -1,5 +1,14 @@
 const vert = /*wgsl*/`
 
+// TODO: 1262 how to remove this from vertex shader
+// please check TODO: 1262
+
+struct Variable{
+    init: f32,
+    circleRadius:f32,
+    circlePosition:vec2<f32>
+}
+
 @vertex
 fn main(
     @location(0) position: vec4<f32>,

--- a/examples/noise1/compute.js
+++ b/examples/noise1/compute.js
@@ -15,7 +15,6 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
 
     if(variables.valueNoiseCreated != 1){
 

--- a/examples/noise1/frag.js
+++ b/examples/noise1/frag.js
@@ -3,6 +3,10 @@ import { snoise } from '../../src/core/noise2d.js';
 
 const frag = /*wgsl*/`
 
+struct Variable{
+    valueNoiseCreated:f32,
+}
+
 ${fnusin}
 ${snoise}
 

--- a/examples/noise1/index.js
+++ b/examples/noise1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const noise1 = {
     vert,
     compute,
@@ -9,8 +8,8 @@ const noise1 = {
     init: async points => {
         const numPoints = 800*800;
         points.addUniform('value_noise_data_length', numPoints);
-        points.addStorage('value_noise_data', numPoints, 'f32', 1, ShaderType.COMPUTE);
-        points.addStorage('variables', 1, 'Variable', 1, ShaderType.COMPUTE);
+        points.addStorage('value_noise_data', numPoints, 'f32', 1);
+        points.addStorage('variables', 1, 'Variable', 1);
     },
     update: points => {
 

--- a/examples/noise1/vert.js
+++ b/examples/noise1/vert.js
@@ -1,5 +1,9 @@
 const vert = /*wgsl*/`
 
+struct Variable{
+    valueNoiseCreated:f32,
+}
+
 @vertex
 fn main(
     @location(0) position: vec4<f32>,

--- a/examples/noisecircle1/compute.js
+++ b/examples/noisecircle1/compute.js
@@ -1,8 +1,4 @@
-import { fnusin, fusin } from '../../src/core/defaultFunctions.js';
 const compute = /*wgsl*/`
-
-${fnusin}
-${fusin}
 
 const workgroupSize = 8;
 

--- a/examples/noisecircle1/frag.js
+++ b/examples/noisecircle1/frag.js
@@ -26,7 +26,7 @@ fn main(
     ) -> @location(0) vec4<f32> {
 
     let time = params.time;
-    let point = points[0];
+    // let point = points[0];
 
     var circle = sdfCircle(vec2(.5,.5) * ratio, .2, .1, uvr);
 

--- a/examples/noisecircle1/frag.js
+++ b/examples/noisecircle1/frag.js
@@ -1,16 +1,9 @@
-import { fnusin, polar, rotateVector, sdfCircle, sdfLine, sdfLine2, sdfSegment, sdfSquare } from '../../src/core/defaultFunctions.js';
+import { sdfCircle } from '../../src/core/defaultFunctions.js';
 import { snoise } from '../../src/core/noise2d.js';
 
 const frag = /*wgsl*/`
 
-${fnusin}
-${sdfSegment}
-${sdfLine}
-${polar}
 ${sdfCircle}
-${rotateVector}
-${sdfSquare}
-${sdfLine2}
 ${snoise}
 
 // this looks like a sunset
@@ -33,14 +26,10 @@ fn main(
     var n1 = (snoise(uvr * 5.14 + 200 * fract(time * -.01))+1)*.5;
     //var n2 = (snoise(uvr * 15.14 + 200 * fract(time * -.01))+1)*.5;
     let skewMask = vec2(1, 1.1);
-    var mask = (1-sdfCircle(vec2(.5,.5) * ratio, .0999, .5, uvr * skewMask ));
+    let mask = (1-sdfCircle(vec2(.5,.5) * ratio, .0999, .5, uvr * skewMask ));
     let result = vec4(1) * mask * n1 * circle + circle;
 
-
-
     var finalColor:vec4<f32> = mask * vec4(1,.5,0,1) + mix(  vec4(1,0,0,result.a),  vec4(1,.5,0,1), result );
-
-
 
     return finalColor;
 }

--- a/examples/noisecircle1/index.js
+++ b/examples/noisecircle1/index.js
@@ -1,6 +1,7 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
+import { ShaderType } from './../../src/absulit.points.module.js';
 const noisecircle1 = {
     vert,
     compute,
@@ -8,7 +9,7 @@ const noisecircle1 = {
     init: async points => {
         const numPoints = 128;
         points.addUniform('numPoints', numPoints);
-        points.addStorage('points', numPoints, 'vec2<f32>', 2);
+        points.addStorage('points', numPoints, 'vec2<f32>', 2, ShaderType.COMPUTE);
     },
     update: points => {
 

--- a/examples/noisecircle1/index.js
+++ b/examples/noisecircle1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from './../../src/absulit.points.module.js';
 const noisecircle1 = {
     vert,
     compute,
@@ -9,7 +8,7 @@ const noisecircle1 = {
     init: async points => {
         const numPoints = 128;
         points.addUniform('numPoints', numPoints);
-        points.addStorage('points', numPoints, 'vec2<f32>', 2, ShaderType.COMPUTE);
+        points.addStorage('points', numPoints, 'vec2<f32>', 2);
     },
     update: points => {
 

--- a/examples/pointstitle1/compute.js
+++ b/examples/pointstitle1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/pointstitle1/frag.js
+++ b/examples/pointstitle1/frag.js
@@ -1,12 +1,11 @@
 import { RED } from '../../src/core/color.js';
 import { showDebugFrame } from '../../src/core/debug.js';
-import { fnusin, sdfCircle, sdfLine, sdfSegment, brightness } from '../../src/core/defaultFunctions.js';
+import { sdfCircle, sdfLine, sdfSegment, brightness } from '../../src/core/defaultFunctions.js';
 import { sprite, texturePosition } from './../../src/core/image.js';
 import { snoise } from './../../src/core/noise2d.js';
 
 const frag = /*wgsl*/`
 
-${fnusin}
 ${texturePosition}
 ${sdfSegment}
 ${sdfLine}

--- a/examples/pointstitle1/index.js
+++ b/examples/pointstitle1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 
 const pointstitle1 = {
     vert,
@@ -9,22 +8,10 @@ const pointstitle1 = {
     frag,
     init: async points => {
 
-        await points.addTextureImage(
-            'image',
-            './../../img/gratia_800x800.jpg',
-            ShaderType.FRAGMENT
-        );
-        await points.addTextureImage('font', './../img/inconsolata_regular_8x22.png', ShaderType.FRAGMENT);
+        await points.addTextureImage('image', './../../img/gratia_800x800.jpg');
+        await points.addTextureImage('font', './../img/inconsolata_regular_8x22.png');
 
-        let descriptor = {
-            addressModeU: 'clamp-to-edge',
-            addressModeV: 'clamp-to-edge',
-            magFilter: 'nearest',
-            minFilter: 'nearest',
-            mipmapFilter: 'nearest',
-            //maxAnisotropy: 10,
-        }
-        points.addSampler('imageSampler', null, ShaderType.FRAGMENT);
+        points.addSampler('imageSampler', null);
 
     },
     update: points => {

--- a/examples/random1/compute.js
+++ b/examples/random1/compute.js
@@ -1,18 +1,5 @@
 const compute = /*wgsl*/`
 
-struct Variables{
-    testValue: f32
-}
-
-struct Chemical{
-    a: f32,
-    b: f32
-}
-
-struct Particles{
-    chemicals: array<Chemical>
-}
-
 struct Star{
     a: f32,
     b: f32,
@@ -26,8 +13,6 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
     let dims: vec2<u32> = textureDimensions(feedbackTexture, 0);
     var rgba = textureSampleLevel(feedbackTexture, feedbackSampler, vec2(0),  0.0).rgba;
 
@@ -37,8 +22,6 @@ fn main(
     let star = stars[0];
 
     textureStore(outputTex, vec2<u32>( u32(r * 800.) ,  u32(r2 * 800.) ), vec4<f32>(1, params.sliderA,0,1));
-
-    //textureStore(outputTex, vec2<u32>(0,0), rgba);
 }
 `;
 

--- a/examples/random1/frag.js
+++ b/examples/random1/frag.js
@@ -3,12 +3,7 @@ import { texturePosition } from '../../src/core/image.js';
 
 const frag = /*wgsl*/`
 
-struct Particle{
-    x: f32,
-    y: f32
-}
-
-struct Star{
+struct Star {
     a: f32,
     b: f32,
     c: f32,
@@ -29,7 +24,6 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    // let star = stars[0];
 
     let startPosition = vec2(0.);
     let texColor = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr, false);

--- a/examples/random1/frag.js
+++ b/examples/random1/frag.js
@@ -29,7 +29,7 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    let star = stars[0];
+    // let star = stars[0];
 
     let startPosition = vec2(0.);
     let texColor = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr, false);

--- a/examples/random1/index.js
+++ b/examples/random1/index.js
@@ -1,6 +1,7 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
+import { ShaderType } from './../../src/absulit.points.module.js';
 const random1 = {
     vert,
     compute,
@@ -8,7 +9,7 @@ const random1 = {
     init: async points => {
         points.addUniform('randNumber', 0);
         points.addUniform('randNumber2', 0);
-        points.addStorage('stars', 800*800, 'Star', 4);
+        points.addStorage('stars', 800*800, 'Star', 4, ShaderType.COMPUTE);
         points.addSampler('feedbackSampler');
         points.addTexture2d('feedbackTexture', true);
         points.addBindingTexture('outputTex', 'computeTexture');

--- a/examples/random1/index.js
+++ b/examples/random1/index.js
@@ -9,7 +9,7 @@ const random1 = {
     init: async points => {
         points.addUniform('randNumber', 0);
         points.addUniform('randNumber2', 0);
-        points.addStorage('stars', 800*800, 'Star', 4, ShaderType.COMPUTE);
+        points.addStorage('stars', 800*800, 'Star', 4);
         points.addSampler('feedbackSampler');
         points.addTexture2d('feedbackTexture', true);
         points.addBindingTexture('outputTex', 'computeTexture');

--- a/examples/random1/vert.js
+++ b/examples/random1/vert.js
@@ -1,10 +1,5 @@
 const vert = /*wgsl*/`
 
-struct Particle{
-    x: f32,
-    y: f32
-}
-
 struct Star{
     a: f32,
     b: f32,

--- a/examples/random2/compute.js
+++ b/examples/random2/compute.js
@@ -1,43 +1,14 @@
 const compute = /*wgsl*/`
 
-struct Variables{
-    testValue: f32
-}
-
-struct Chemical{
-    a: f32,
-    b: f32
-}
-
-struct Particles{
-    chemicals: array<Chemical>
-}
-
-struct Star{
-    a: f32,
-    b: f32,
-    c: f32,
-    d: f32,
-}
-
 @compute @workgroup_size(8,8,1)
 fn main(
     @builtin(global_invocation_id) GlobalId: vec3<u32>,
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
     let dims: vec2<u32> = textureDimensions(feedbackTexture, 0);
     var rgba = textureSampleLevel(feedbackTexture, feedbackSampler, vec2(0),  0.0).rgba;
 
-    var r = params.randNumber;
-    var r2 = params.randNumber2;
-
-    r = rands[0];
-    r2 = rands[1];
-
-    let star = stars[0];
 
     for(var i:u32; i< 800*800; i++){
         let x = i % 800;
@@ -45,10 +16,6 @@ fn main(
         let c = rands[i];
         textureStore(outputTex, vec2<u32>( u32(x) ,  u32(y) ), vec4<f32>(c));
     }
-    // textureStore(outputTex, vec2<u32>( u32(r * 800.) ,  u32(r2 * 800.) ), vec4<f32>(1, params.sliderA,0,1));
-
-
-    //textureStore(outputTex, vec2<u32>(0,0), rgba);
 }
 `;
 

--- a/examples/random2/frag.js
+++ b/examples/random2/frag.js
@@ -29,9 +29,6 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    let star = stars[0];
-    let rand = rands[0];
-
     let startPosition = vec2(0.,0.);
     let texColor = texturePosition(feedbackTexture, feedbackSampler, startPosition, uvr, false);
     let texColorCompute = texturePosition(computeTexture, feedbackSampler, startPosition, uvr, false);

--- a/examples/random2/index.js
+++ b/examples/random2/index.js
@@ -8,12 +8,11 @@ const random2 = {
     init: async points => {
         points.addUniform('randNumber', 0);
         points.addUniform('randNumber2', 0);
-        points.addStorage('stars', 800*800, 'Star', 4);
         let data = [];
         for (let k = 0; k < 800*800; k++) {
             data.push(Math.random());
         }
-        points.addStorageMap('rands', [0,0], 'f32');
+        points.addStorageMap('rands', [0,0], 'array<f32>');
         points.addSampler('feedbackSampler');
         points.addTexture2d('feedbackTexture', true);
         points.addBindingTexture('outputTex', 'computeTexture');

--- a/examples/random2/vert.js
+++ b/examples/random2/vert.js
@@ -1,17 +1,5 @@
 const vert = /*wgsl*/`
 
-struct Particle{
-    x: f32,
-    y: f32
-}
-
-struct Star{
-    a: f32,
-    b: f32,
-    c: f32,
-    d: f32,
-}
-
 @vertex
 fn main(
     @location(0) position: vec4<f32>,

--- a/examples/random3/compute.js
+++ b/examples/random3/compute.js
@@ -9,13 +9,6 @@ ${rand}
 ${RGBAFromHSV}
 ${fnusin}
 
-
-struct Star{
-    a: f32,
-    b: f32,
-    c: f32,
-    d: f32,
-}
 const workgroupSize = 8;
 
 @compute @workgroup_size(workgroupSize,workgroupSize,1)
@@ -24,19 +17,9 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
-    // let dims: vec2<u32> = textureDimensions(feedbackTexture, 0);
-    _ = textureSampleLevel(feedbackTexture, feedbackSampler, vec2(0),  0.0).rgba;
-
-    //let star = stars[0];
-
-    //----------------------------
-    //let dims: vec2<u32> = textureDimensions(feedbackTexture, 0);
 
     let numColumns:f32 = params.screenWidth;
     let numRows:f32 = params.screenHeight;
-    //let constant = u32(numColumns) / 93u;
 
     let numColumnsPiece:i32 = i32(numColumns / f32(workgroupSize));
     let numRowsPiece:i32 = i32(numRows / f32(workgroupSize));
@@ -65,23 +48,13 @@ fn main(
                 v = 1.;
             }
 
-            //textureStore(outputTex, vec2<u32>(ux,uy), vec4(randNumber));
-            //textureStore(outputTex, vec2<u32>(ux,uy), RGBAFromHSV(randNumber, 1, 1));
-            //textureStore(outputTex, vec2<u32>(ux,uy), RGBAFromHSV( fnusin(randNumber), 1, 1));
-            //textureStore(outputTex, vec2<u32>(ux,uy), vec4( fnusin(randNumber)));
+            // textureStore(outputTex, vec2<u32>(ux,uy), vec4(randNumber));
+            // textureStore(outputTex, vec2<u32>(ux,uy), RGBAFromHSV(randNumber, 1, 1));
+            // textureStore(outputTex, vec2<u32>(ux,uy), RGBAFromHSV( fnusin(randNumber), 1, 1));
+            // textureStore(outputTex, vec2<u32>(ux,uy), vec4( fnusin(randNumber)));
             textureStore(outputTex, vec2<u32>(ux,uy), vec4( fract(randNumber + fnusin(1))));
         }
     }
-
-    // let numPixels = i32(numColumns * numRows);
-    // for (var index:i32 = 0; index < numPixels; index++){
-    //     let x = u32(f32(index) % numColumns);
-    //     let y = u32(f32(index) / numRows);
-    //     let randNumber = rand();
-    //     textureStore(outputTex, vec2<u32>(x,y), vec4(randNumber));
-    // }
-
-
 }
 `;
 

--- a/examples/random3/frag.js
+++ b/examples/random3/frag.js
@@ -3,18 +3,6 @@ import { texturePosition } from '../../src/core/image.js';
 
 const frag = /*wgsl*/`
 
-struct Particle{
-    x: f32,
-    y: f32
-}
-
-struct Star{
-    a: f32,
-    b: f32,
-    c: f32,
-    d: f32,
-}
-
 ${fnusin}
 ${fusin}
 ${texturePosition}
@@ -30,12 +18,7 @@ fn main(
     ) -> @location(0) vec4<f32> {
 
     let startPosition = vec2(0.);
-    _ = textureSample(feedbackTexture, feedbackSampler, uvr);
     let texColorCompute = texturePosition(computeTexture, feedbackSampler, startPosition, uvr, false);
-
-
-
-
     let finalColor:vec4<f32> = texColorCompute;
 
     return finalColor;

--- a/examples/random3/vert.js
+++ b/examples/random3/vert.js
@@ -1,17 +1,5 @@
 const vert = /*wgsl*/`
 
-struct Particle{
-    x: f32,
-    y: f32
-}
-
-struct Star{
-    a: f32,
-    b: f32,
-    c: f32,
-    d: f32,
-}
-
 @vertex
 fn main(
     @location(0) position: vec4<f32>,

--- a/examples/renderpasses1/index.js
+++ b/examples/renderpasses1/index.js
@@ -14,13 +14,13 @@ const renderpasses1 = {
      */
     renderPasses: [
         new RenderPass(vert1, compute1, frag1),
-        // new RenderPass(vert2, compute2, frag2),
+        new RenderPass(vert2, compute2, frag2),
     ],
     init: async points => {
-        // points.addSampler('imageSampler', null, ShaderType.FRAGMENT);
+        points.addSampler('imageSampler', null, ShaderType.FRAGMENT);
         // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
         // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
         points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
         points.addTexture2d('feedbackTexture', true);
     },

--- a/examples/renderpasses1/index.js
+++ b/examples/renderpasses1/index.js
@@ -14,7 +14,7 @@ const renderpasses1 = {
      */
     renderPasses: [
         new RenderPass(vert1, compute1, frag1),
-        new RenderPass(vert2, compute2, frag2),
+        // new RenderPass(vert2, compute2, frag2),
     ],
     init: async points => {
         // points.addSampler('imageSampler', null, ShaderType.FRAGMENT);

--- a/examples/renderpasses1/index.js
+++ b/examples/renderpasses1/index.js
@@ -17,7 +17,12 @@ const renderpasses1 = {
         new RenderPass(vert2, compute2, frag2),
     ],
     init: async points => {
-        ShaderType
+        // points.addSampler('imageSampler', null, ShaderType.FRAGMENT);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
+        // await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
+        points.addTexture2d('feedbackTexture', true);
     },
     update: points => {
 

--- a/examples/renderpasses1/index.js
+++ b/examples/renderpasses1/index.js
@@ -6,7 +6,7 @@ import vert2 from './renderpass2/vert.js';
 import compute2 from './renderpass2/compute.js';
 import frag2 from './renderpass2/frag.js';
 
-import { RenderPass, ShaderType } from '../../src/absulit.points.module.js';
+import { RenderPass } from '../../src/absulit.points.module.js';
 
 const renderpasses1 = {
     /**
@@ -17,11 +17,11 @@ const renderpasses1 = {
         new RenderPass(vert2, compute2, frag2),
     ],
     init: async points => {
-        points.addSampler('imageSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
+        points.addSampler('imageSampler', null);
+        // await points.addTextureImage('image', './../img/carmen_lyra_423x643.jpg');
+        // await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        await points.addTextureImage('image', './../img/absulit_800x800.jpg');
+        points.addSampler('feedbackSampler', null);
         points.addTexture2d('feedbackTexture', true);
     },
     update: points => {

--- a/examples/renderpasses1/index.js
+++ b/examples/renderpasses1/index.js
@@ -1,0 +1,27 @@
+import vert1 from './renderpass1/vert.js';
+import compute1 from './renderpass1/compute.js';
+import frag1 from './renderpass1/frag.js';
+
+import vert2 from './renderpass2/vert.js';
+import compute2 from './renderpass2/compute.js';
+import frag2 from './renderpass2/frag.js';
+
+import { RenderPass, ShaderType } from '../../src/absulit.points.module.js';
+
+const renderpasses1 = {
+    /**
+     * Render Passes expect to have an order
+     */
+    renderPasses: [
+        new RenderPass(vert1, compute1, frag1),
+        new RenderPass(vert2, compute2, frag2),
+    ],
+    init: async points => {
+        ShaderType
+    },
+    update: points => {
+
+    }
+}
+
+export default renderpasses1;

--- a/examples/renderpasses1/renderpass1/compute.js
+++ b/examples/renderpasses1/renderpass1/compute.js
@@ -1,0 +1,13 @@
+const compute = /*wgsl*/`
+
+@compute @workgroup_size(8,8,1)
+fn main(
+    @builtin(global_invocation_id) GlobalId: vec3<u32>,
+    @builtin(workgroup_id) WorkGroupID: vec3<u32>,
+    @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
+) {
+    let time = params.time;
+}
+`;
+
+export default compute;

--- a/examples/renderpasses1/renderpass1/compute.js
+++ b/examples/renderpasses1/renderpass1/compute.js
@@ -6,8 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    // _ = params.time;
-    // _ = textureDimensions(feedbackTexture, 0);
+    // compute code
 }
 `;
 

--- a/examples/renderpasses1/renderpass1/compute.js
+++ b/examples/renderpasses1/renderpass1/compute.js
@@ -6,7 +6,8 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    _ = params.time;
+    _ = textureDimensions(feedbackTexture, 0);
 }
 `;
 

--- a/examples/renderpasses1/renderpass1/compute.js
+++ b/examples/renderpasses1/renderpass1/compute.js
@@ -6,8 +6,8 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
-    _ = textureDimensions(feedbackTexture, 0);
+    // _ = params.time;
+    // _ = textureDimensions(feedbackTexture, 0);
 }
 `;
 

--- a/examples/renderpasses1/renderpass1/frag.js
+++ b/examples/renderpasses1/renderpass1/frag.js
@@ -1,0 +1,29 @@
+import { fnusin } from "../../../src/core/defaultFunctions.js";
+
+const frag = /*wgsl*/`
+
+${fnusin}
+
+@fragment
+fn main(
+    @location(0) color: vec4<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) ratio: vec2<f32>,  // relation between params.screenWidth and params.screenHeight
+    @location(3) uvr: vec2<f32>,    // uv with aspect ratio corrected
+    @location(4) mouse: vec2<f32>,
+    @builtin(position) position: vec4<f32>
+) -> @location(0) vec4<f32> {
+
+    let cellSize = 20. + 10. * fnusin(1.);
+    let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
+    let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );
+    let c = fnusin(uvr.x * uvr.y * 10.);
+    let d = distance(a,b);
+    let f = d * uvr.x * uvr.y;
+    let finalColor:vec4<f32> = vec4(a*d,f*c*a,f, 1.);
+
+    return finalColor;
+}
+`;
+
+export default frag;

--- a/examples/renderpasses1/renderpass1/frag.js
+++ b/examples/renderpasses1/renderpass1/frag.js
@@ -1,9 +1,10 @@
-import { fnusin } from "../../../src/core/defaultFunctions.js";
+import { fnusin, fusin } from "../../../src/core/defaultFunctions.js";
 import { texturePosition } from "../../../src/core/image.js";
 
 const frag = /*wgsl*/`
 
 ${fnusin}
+${fusin}
 ${texturePosition}
 
 @fragment
@@ -16,10 +17,16 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    // let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
     _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
 
-    let finalColor = vec4(1.,0,0,1);
+    let d = distance(uvr, vec2(.5 + .1 * fusin(2), .5  + .1 * fusin(4.123)));
+    var c = 1.;
+    if(d > .1){
+        c = 0;
+    }
+
+    let finalColor = imageColor + c * vec4(1);
 
     return finalColor;
 }

--- a/examples/renderpasses1/renderpass1/frag.js
+++ b/examples/renderpasses1/renderpass1/frag.js
@@ -1,8 +1,10 @@
 import { fnusin } from "../../../src/core/defaultFunctions.js";
+import { texturePosition } from "../../../src/core/image.js";
 
 const frag = /*wgsl*/`
 
 ${fnusin}
+${texturePosition}
 
 @fragment
 fn main(
@@ -14,13 +16,10 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    let cellSize = 20. + 10. * fnusin(1.);
-    let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
-    let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );
-    let c = fnusin(uvr.x * uvr.y * 10.);
-    let d = distance(a,b);
-    let f = d * uvr.x * uvr.y;
-    let finalColor:vec4<f32> = vec4(a*d,f*c*a,f, 1.);
+    // let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
+
+    let finalColor = vec4(1.,0,0,1);
 
     return finalColor;
 }

--- a/examples/renderpasses1/renderpass1/frag.js
+++ b/examples/renderpasses1/renderpass1/frag.js
@@ -18,6 +18,7 @@ fn main(
 ) -> @location(0) vec4<f32> {
 
     let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    // first render pass doesn't use the feedback texture, it's the second pass
     // _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
 
     let d = distance(uvr, vec2(.5 + .1 * fusin(2), .5  + .1 * fusin(4.123)));

--- a/examples/renderpasses1/renderpass1/frag.js
+++ b/examples/renderpasses1/renderpass1/frag.js
@@ -18,7 +18,7 @@ fn main(
 ) -> @location(0) vec4<f32> {
 
     let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
-    _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
+    // _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
 
     let d = distance(uvr, vec2(.5 + .1 * fusin(2), .5  + .1 * fusin(4.123)));
     var c = 1.;

--- a/examples/renderpasses1/renderpass1/vert.js
+++ b/examples/renderpasses1/renderpass1/vert.js
@@ -1,0 +1,15 @@
+const vert = /*wgsl*/`
+
+@vertex
+fn main(
+    @location(0) position: vec4<f32>,
+    @location(1) color: vec4<f32>,
+    @location(2) uv: vec2<f32>,
+    @builtin(vertex_index) vertexIndex: u32
+) -> Fragment {
+
+    return defaultVertexBody(position, color, uv);
+}
+`;
+
+export default vert;

--- a/examples/renderpasses1/renderpass2/compute.js
+++ b/examples/renderpasses1/renderpass2/compute.js
@@ -1,0 +1,13 @@
+const compute = /*wgsl*/`
+
+@compute @workgroup_size(8,8,1)
+fn main(
+    @builtin(global_invocation_id) GlobalId: vec3<u32>,
+    @builtin(workgroup_id) WorkGroupID: vec3<u32>,
+    @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
+) {
+    let time = params.time;
+}
+`;
+
+export default compute;

--- a/examples/renderpasses1/renderpass2/compute.js
+++ b/examples/renderpasses1/renderpass2/compute.js
@@ -6,8 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    // _ = params.time;
-    // _ = textureDimensions(feedbackTexture, 0);
+    // compute code
 }
 `;
 

--- a/examples/renderpasses1/renderpass2/compute.js
+++ b/examples/renderpasses1/renderpass2/compute.js
@@ -6,7 +6,8 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    _ = params.time;
+    _ = textureDimensions(feedbackTexture, 0);
 }
 `;
 

--- a/examples/renderpasses1/renderpass2/compute.js
+++ b/examples/renderpasses1/renderpass2/compute.js
@@ -6,8 +6,8 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    _ = params.time;
-    _ = textureDimensions(feedbackTexture, 0);
+    // _ = params.time;
+    // _ = textureDimensions(feedbackTexture, 0);
 }
 `;
 

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -1,14 +1,14 @@
-import { fnusin, rotateVector } from "../../../src/core/defaultFunctions.js";
+import { rotateVector } from "../../../src/core/defaultFunctions.js";
 import { texturePosition } from "../../../src/core/image.js";
 import { PI } from '../../../src/core/defaultConstants.js';
 
 const frag = /*wgsl*/`
 
-${fnusin}
 ${texturePosition}
 ${rotateVector}
 ${PI}
 
+// TODO: move to effect module and add reference
 fn blur9(image: texture_2d<f32>, imageSampler:sampler, position:vec2<f32>, uv:vec2<f32>, resolution: vec2<f32>, direction: vec2<f32>) -> vec4<f32> {
     var color = vec4(0.0);
     let off1 = vec2(1.3846153846) * direction;
@@ -31,6 +31,7 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
+    // second pass doesn't use the image, that's the first pass
     // _ = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
     let feedbackColor = blur9(feedbackTexture, feedbackSampler, vec2(0.,0), uvr, vec2(100.,100.), rotateVector(vec2(.4,.0), 2 * PI * params.sliderA));
 

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -1,0 +1,29 @@
+import { fnusin } from "../../../src/core/defaultFunctions.js";
+
+const frag = /*wgsl*/`
+
+${fnusin}
+
+@fragment
+fn main(
+    @location(0) color: vec4<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) ratio: vec2<f32>,  // relation between params.screenWidth and params.screenHeight
+    @location(3) uvr: vec2<f32>,    // uv with aspect ratio corrected
+    @location(4) mouse: vec2<f32>,
+    @builtin(position) position: vec4<f32>
+) -> @location(0) vec4<f32> {
+
+    let cellSize = 20. + 10. * fnusin(1.);
+    let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
+    let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );
+    let c = fnusin(uvr.x * uvr.y * 10.);
+    let d = distance(a,b);
+    let f = d * uvr.x * uvr.y;
+    let finalColor:vec4<f32> = vec4(a*d,f*c*a,f, 1.);
+
+    return finalColor;
+}
+`;
+
+export default frag;

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -31,7 +31,7 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    _ = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    // _ = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
     let feedbackColor = blur9(feedbackTexture, feedbackSampler, vec2(0.,0), uvr, vec2(100.,100.), rotateVector(vec2(.4,.0), 2 * PI * params.sliderA));
 
     let finalColor = feedbackColor;

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -16,9 +16,10 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    // let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
 
-    let finalColor = imageColor;
+    let finalColor = vec4(1.,0,0,1);
 
     return finalColor;
 }

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -1,8 +1,10 @@
 import { fnusin } from "../../../src/core/defaultFunctions.js";
+import { texturePosition } from "../../../src/core/image.js";
 
 const frag = /*wgsl*/`
 
 ${fnusin}
+${texturePosition}
 
 @fragment
 fn main(
@@ -14,13 +16,9 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    let cellSize = 20. + 10. * fnusin(1.);
-    let a = sin(uvr.x  * cellSize) * sin(uvr.y * cellSize);
-    let b = sin(uvr.x * uvr.y * 10. * 9.1 * .25 );
-    let c = fnusin(uvr.x * uvr.y * 10.);
-    let d = distance(a,b);
-    let f = d * uvr.x * uvr.y;
-    let finalColor:vec4<f32> = vec4(a*d,f*c*a,f, 1.);
+    let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+
+    let finalColor = imageColor;
 
     return finalColor;
 }

--- a/examples/renderpasses1/renderpass2/frag.js
+++ b/examples/renderpasses1/renderpass2/frag.js
@@ -1,10 +1,25 @@
-import { fnusin } from "../../../src/core/defaultFunctions.js";
+import { fnusin, rotateVector } from "../../../src/core/defaultFunctions.js";
 import { texturePosition } from "../../../src/core/image.js";
+import { PI } from '../../../src/core/defaultConstants.js';
 
 const frag = /*wgsl*/`
 
 ${fnusin}
 ${texturePosition}
+${rotateVector}
+${PI}
+
+fn blur9(image: texture_2d<f32>, imageSampler:sampler, position:vec2<f32>, uv:vec2<f32>, resolution: vec2<f32>, direction: vec2<f32>) -> vec4<f32> {
+    var color = vec4(0.0);
+    let off1 = vec2(1.3846153846) * direction;
+    let off2 = vec2(3.2307692308) * direction;
+    color += texturePosition(image, imageSampler, position, uv, true) * 0.2270270270;
+    color += texturePosition(image, imageSampler, position, uv + (off1 / resolution), true) * 0.3162162162;
+    color += texturePosition(image, imageSampler, position, uv - (off1 / resolution), true) * 0.3162162162;
+    color += texturePosition(image, imageSampler, position, uv + (off2 / resolution), true) * 0.0702702703;
+    color += texturePosition(image, imageSampler, position, uv - (off2 / resolution), true) * 0.0702702703;
+    return color;
+}
 
 @fragment
 fn main(
@@ -16,10 +31,10 @@ fn main(
     @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    // let imageColor = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
-    _ = texturePosition(feedbackTexture, feedbackSampler, vec2(0,0), uvr, true);
+    _ = texturePosition(image, imageSampler, vec2(0,0), uvr, true);
+    let feedbackColor = blur9(feedbackTexture, feedbackSampler, vec2(0.,0), uvr, vec2(100.,100.), rotateVector(vec2(.4,.0), 2 * PI * params.sliderA));
 
-    let finalColor = vec4(1.,0,0,1);
+    let finalColor = feedbackColor;
 
     return finalColor;
 }

--- a/examples/renderpasses1/renderpass2/vert.js
+++ b/examples/renderpasses1/renderpass2/vert.js
@@ -1,0 +1,15 @@
+const vert = /*wgsl*/`
+
+@vertex
+fn main(
+    @location(0) position: vec4<f32>,
+    @location(1) color: vec4<f32>,
+    @location(2) uv: vec2<f32>,
+    @builtin(vertex_index) vertexIndex: u32
+) -> Fragment {
+
+    return defaultVertexBody(position, color, uv);
+}
+`;
+
+export default vert;

--- a/examples/shapes1/compute.js
+++ b/examples/shapes1/compute.js
@@ -1,9 +1,4 @@
-import { fnusin, fusin } from '../../src/core/defaultFunctions.js';
-
 const compute = /*wgsl*/`
-
-${fnusin}
-${fusin}
 
 const workgroupSize = 8;
 

--- a/examples/shapes1/frag.js
+++ b/examples/shapes1/frag.js
@@ -1,11 +1,18 @@
-import { fnusin, polar, rotateVector, sdfCircle, sdfLine, sdfLine2, sdfSegment, sdfSquare } from '../../src/core/defaultFunctions.js';
+import {
+    fnusin,
+    rotateVector,
+    sdfCircle,
+    sdfLine,
+    sdfLine2,
+    sdfSegment,
+    sdfSquare
+} from '../../src/core/defaultFunctions.js';
 
 const frag = /*wgsl*/`
 
 ${fnusin}
 ${sdfSegment}
 ${sdfLine}
-${polar}
 ${sdfCircle}
 ${rotateVector}
 ${sdfSquare}

--- a/examples/shapes1/vert.js
+++ b/examples/shapes1/vert.js
@@ -1,10 +1,5 @@
 const vert = /*wgsl*/`
 
-struct Variable{
-    particlesCreated: f32,
-}
-
-
 @vertex
 fn main(
     @location(0) position: vec4<f32>,

--- a/examples/shapes2/compute.js
+++ b/examples/shapes2/compute.js
@@ -62,9 +62,6 @@ fn main(
     let numRows:f32 = params.screenHeight;
     let numColumnsPiece:i32 = i32(numColumns / f32(workgroupSize));
     let numRowsPiece:i32 = i32(numRows / f32(workgroupSize));
-    //let constant = u32(numColumns) / 93u;
-
-
 
     var x = 450.;
     var y = 450.;

--- a/examples/shapes2/frag.js
+++ b/examples/shapes2/frag.js
@@ -16,8 +16,7 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    _ = points[0];
-    let texColorCompute = textureSample(computeTexture, feedbackSampler, uvr);
+    let texColorCompute = textureSample(computeTexture, feedbackSampler, uvr).g;
 
     let texColorComputeR = textureSample(computeTexture, feedbackSampler, uvr + vec2(CHROMATIC_DISPLACEMENT, 0.)).r;
     let texColorComputeB = textureSample(computeTexture, feedbackSampler, uvr - vec2(CHROMATIC_DISPLACEMENT, 0.)).b;

--- a/examples/shapes2/index.js
+++ b/examples/shapes2/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const shapes2 = {
     vert,
     compute,
@@ -10,7 +9,7 @@ const shapes2 = {
         const numPoints = 800*800;
         points.addUniform('numPoints', numPoints);
         points.addStorage('points', numPoints, 'vec4<f32>', 4);
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
+        points.addSampler('feedbackSampler', null);
         points.addBindingTexture('outputTex', 'computeTexture');
     },
     update: points => {

--- a/examples/spritesheet1/compute.js
+++ b/examples/spritesheet1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/spritesheet1/frag.js
+++ b/examples/spritesheet1/frag.js
@@ -1,16 +1,24 @@
-import { fnusin, rotateVector, sdfLine, sdfSegment, sdfSquare } from '../../src/core/defaultFunctions.js';
-import { snoise } from '../../src/core/noise2d.js';
 import { PI } from '../../src/core/defaultConstants.js';
-import { decodeNumberSprite, sprite, texturePosition } from '../../src/core/image.js';
 import { showDebugCross } from '../../src/core/debug.js';
 import { GREEN, layer, RED, sdfSmooth } from './../../src/core/color.js';
+import {
+    fnusin,
+    rotateVector,
+    sdfLine, sdfSegment,
+    sdfSquare
+} from '../../src/core/defaultFunctions.js';
+
+import {
+    decodeNumberSprite,
+    sprite,
+    texturePosition
+} from '../../src/core/image.js';
 
 const frag = /*wgsl*/`
 
 ${fnusin}
 ${sdfSegment}
 ${sdfLine}
-${snoise}
 ${PI}
 ${texturePosition}
 ${showDebugCross}
@@ -33,7 +41,6 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    let n1 = snoise(uv * fnusin(1) * params.sliderB);
     let scaleDigits = .25;
     let startPosition = vec2(.5, .5) * ratio * scaleDigits;
     //let rgbaImage = texturePosition(image, imageSampler, startPosition, uvr, true); //* .998046;

--- a/examples/spritesheet1/index.js
+++ b/examples/spritesheet1/index.js
@@ -1,7 +1,6 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const spritesheet1 = {
     vert,
     compute,
@@ -15,18 +14,18 @@ const spritesheet1 = {
             mipmapFilter: 'nearest',
             //maxAnisotropy: 10,
         }
-        points.addSampler('imageSampler', descriptor, ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/inconsolata_regular_8x22.png', ShaderType.FRAGMENT);
+        points.addSampler('imageSampler', descriptor);
+        await points.addTextureImage('image', './../img/inconsolata_regular_8x22.png');
         /**
          * sprite sheet animation created by Nelson Yiap
          * https://opengameart.org/users/nelson-yiap
          */
-        await points.addTextureImage('bobbles', './../img/fishing_bobbles_nelson-yiap_24x24.png', ShaderType.FRAGMENT);
+        await points.addTextureImage('bobbles', './../img/fishing_bobbles_nelson-yiap_24x24.png');
         /**
          * penguin sprite by tamashihoshi
          * https://opengameart.org/users/tamashihoshi
          */
-        await points.addTextureImage('penguin', './../img/lr_penguin2_tamashihoshi_32x32.png', ShaderType.FRAGMENT);
+        await points.addTextureImage('penguin', './../img/lr_penguin2_tamashihoshi_32x32.png');
     },
     update: points => {
 

--- a/examples/uvs1/compute.js
+++ b/examples/uvs1/compute.js
@@ -6,7 +6,7 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
+    // compute code
 }
 `;
 

--- a/examples/uvs1/frag.js
+++ b/examples/uvs1/frag.js
@@ -1,8 +1,4 @@
-import { fnusin } from '../../src/core/defaultFunctions.js';
-
 const frag = /*wgsl*/`
-
-${fnusin}
 
 @fragment
 fn main(
@@ -15,10 +11,10 @@ fn main(
     ) -> @location(0) vec4<f32> {
 
     // stretched uv if canvas dimensions are non squared
-    let uvColor:vec4<f32> = vec4( fract(uv * 10), 0,1); 
+    let uvColor:vec4<f32> = vec4( fract(uv * 10), 0,1);
 
     // always square dimensions
-    let uvrColor:vec4<f32> = vec4( fract(uvr * 20), 0,1).rbga; 
+    let uvrColor:vec4<f32> = vec4( fract(uvr * 20), 0,1).rbga;
 
     var factor = 0.;
     if(uv.x > mouse.x){

--- a/examples/uvs1/index.js
+++ b/examples/uvs1/index.js
@@ -1,14 +1,13 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from './../../src/absulit.points.module.js';
 
 const uvs1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        ShaderType
+
     },
     update: points => {
 

--- a/examples/videotexture1/compute.js
+++ b/examples/videotexture1/compute.js
@@ -8,16 +8,11 @@ fn main(
     @builtin(workgroup_id) WorkGroupID: vec3<u32>,
     @builtin(local_invocation_id) LocalInvocationID: vec3<u32>
 ) {
-    let time = params.time;
-
     let videoDims = textureDimensions(video);
-
-
 
     //--------------------------------------------------
     let numColumns:f32 = f32(videoDims.x);
     let numRows:f32 = f32(videoDims.y);
-    //let constant = u32(numColumns) / 93u;
 
     let numColumnsPiece:i32 = i32(numColumns / f32(workgroupSize));
     let numRowsPiece:i32 = i32(numRows / f32(workgroupSize));
@@ -44,19 +39,6 @@ fn main(
         }
     }
     //--------------------------------------------------
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/examples/videotexture1/frag.js
+++ b/examples/videotexture1/frag.js
@@ -1,17 +1,9 @@
-import { brightness, fnusin, fusin, polar, sdfCircle, sdfLine, sdfSegment } from '../../src/core/defaultFunctions.js';
-import { snoise } from '../../src/core/noise2d.js';
+import { fnusin } from '../../src/core/defaultFunctions.js';
 import { texturePosition } from '../../src/core/image.js';
 
 const videotexture1Frag = /*wgsl*/`
 
 ${fnusin}
-${fusin}
-${sdfCircle}
-${sdfSegment}
-${sdfLine}
-${brightness}
-${polar}
-${snoise}
 ${texturePosition}
 
 
@@ -25,35 +17,15 @@ fn main(
         @builtin(position) position: vec4<f32>
     ) -> @location(0) vec4<f32> {
 
-    let n1 = snoise(uv + 2 * fnusin(1));
-
     let dims: vec2<u32> = textureDimensions(image, 0);
     var dimsRatio = f32(dims.x) / f32(dims.y);
 
     let imageUV = uv * vec2(1,-1 * dimsRatio) * ratio.y / params.sliderA;
-    //let oldKingUVClamp = uv * vec2(1,1 * dimsRatio) * ratio.x;
     let lines = sin( uv.x*(uv.x + 3 * fnusin(1))  ) ;
     let startPosition = vec2(0.);
-    let rgbaImage = texturePosition(image, feedbackSampler, startPosition, imageUV * lines, false); //* .998046;
+    let rgbaImage = texturePosition(image, feedbackSampler, startPosition, imageUV, false); //* .998046;
 
-    // let videoDims = textureDimensions(video);
-    // let videoDimsRatio = f32(videoDims.x) / f32(videoDims.y);
-    // let videoUV = uv * vec2(1,-1 * videoDimsRatio) * ratio.y / params.sliderA * .00001;
-
-    // let half_texel = vec2(0.5) / vec2<f32>(textureDimensions(video));
-    // let rgbaVideo = textureSampleBaseClampToEdge(video, videoSampler, videoUV * lines);
     let rgbaCT = texturePosition(computeTexture, feedbackSampler, startPosition, uv / params.sliderA, false);
-
-
-
-    let b = brightness(rgbaImage);
-    let d = distance(uv, rgbaImage.xy);
-
-    //let finalColor:vec4<f32> = mix(  vec4(1,0,0,1)   , vec4(1,1,0,1) , b) * fnusin(d);
-    //let finalColor:vec4<f32> = rgbaImage;
-    //let finalColor:vec4<f32> = vec4(b);
-    let finalColor:vec4<f32> = vec4( b  );
-
 
     return rgbaCT;
 }

--- a/examples/videotexture1/index.js
+++ b/examples/videotexture1/index.js
@@ -1,17 +1,16 @@
 import vert from './vert.js';
 import compute from './compute.js';
 import frag from './frag.js';
-import { ShaderType } from '../../src/absulit.points.module.js';
 const videotexture1 = {
     vert,
     compute,
     frag,
     init: async points => {
-        points.addSampler('feedbackSampler', null, ShaderType.FRAGMENT);
-        // await points.addTextureImage('oldking', './../img/carmen_lyra_423x643.jpg', ShaderType.FRAGMENT);
-        await points.addTextureImage('image', './../img/old_king_600x600.jpg', ShaderType.FRAGMENT);
-        // await points.addTextureImage('image', './../img/absulit_800x800.jpg', ShaderType.FRAGMENT);
-        await points.addTextureVideo('video', './../img/61c6eeaf-87cf5e18.mp4', ShaderType.COMPUTE)
+        points.addSampler('feedbackSampler', null);
+        // await points.addTextureImage('oldking', './../img/carmen_lyra_423x643.jpg');
+        await points.addTextureImage('image', './../img/old_king_600x600.jpg');
+        // await points.addTextureImage('image', './../img/absulit_800x800.jpg');
+        await points.addTextureVideo('video', './../img/61c6eeaf-87cf5e18.mp4')
         points.addBindingTexture('outputTex', 'computeTexture');
 
     },

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -610,8 +610,7 @@ export default class Points {
         this.addUniform(UniformKeys.MOUSE_DELTA_X, this._mouseDeltaX);
         this.addUniform(UniformKeys.MOUSE_DELTA_Y, this._mouseDeltaY);
 
-        renderPasses.forEach(renderPass => {
-            // let i = 0;
+        renderPasses.forEach( (renderPass, index) => {
             let vertexShader = renderPass.vertexShader;
             let computeShader = renderPass.computeShader;
             let fragmentShader = renderPass.fragmentShader;
@@ -650,6 +649,7 @@ export default class Points {
             colorsComputeWGSL = dynamicGroupBindingsCompute + defaultStructs + colorsComputeWGSL;
             colorsFragWGSL = dynamicGroupBindingsFragment + defaultStructs + colorsFragWGSL;
 
+            console.groupCollapsed(`Render Pass ${index}`);
             console.groupCollapsed('VERTEX');
             console.log(colorsVertWGSL);
             console.groupEnd();
@@ -658,6 +658,7 @@ export default class Points {
             console.groupEnd();
             console.groupCollapsed('FRAGMENT');
             console.log(colorsFragWGSL);
+            console.groupEnd();
             console.groupEnd();
 
             this._shaders.push(

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -352,8 +352,11 @@ export default class Points {
 
     async readStorage(name) {
         let storageItem = this._readStorage.find(storageItem => storageItem.name === name);
-        await storageItem.buffer.mapAsync(GPUMapMode.READ)
-        const arrayBuffer = storageItem.buffer.getMappedRange();
+        let arrayBuffer = null;
+        if(storageItem){
+            await storageItem.buffer.mapAsync(GPUMapMode.READ)
+            arrayBuffer = storageItem.buffer.getMappedRange();
+        }
         return new Float32Array(arrayBuffer);
     }
 

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -35,7 +35,7 @@ export class RenderPass {
      * @param {String} computeShader  WGSL Compute Shader in a String.
      * @param {String} fragmentShader  WGSL Fragment Shader in a String.
      */
-    constructor(vertexShader, computeShader, fragmentShader){
+    constructor(vertexShader, computeShader, fragmentShader) {
         this._vertexShader = vertexShader;
         this._computeShader = computeShader;
         this._fragmentShader = fragmentShader;
@@ -53,51 +53,51 @@ export class RenderPass {
         }
     }
 
-    get vertexShader(){
+    get vertexShader() {
         return this._vertexShader;
     }
 
-    get computeShader(){
+    get computeShader() {
         return this._computeShader;
     }
 
-    get fragmentShader(){
+    get fragmentShader() {
         return this._fragmentShader;
     }
 
-    set computePipeline(value){
+    set computePipeline(value) {
         this._computePipeline = value;
     }
 
-    get computePipeline(){
+    get computePipeline() {
         return this._computePipeline;
     }
 
-    set renderPipeline(value){
+    set renderPipeline(value) {
         this._renderPipeline = value;
     }
 
-    get renderPipeline(){
+    get renderPipeline() {
         return this._renderPipeline;
     }
 
-    set computeBindGroup(value){
+    set computeBindGroup(value) {
         this._computeBindGroup = value;
     }
 
-    get computeBindGroup(){
+    get computeBindGroup() {
         return this._computeBindGroup;
     }
 
-    set uniformBindGroup(value){
+    set uniformBindGroup(value) {
         this._uniformBindGroup = value;
     }
 
-    get uniformBindGroup(){
+    get uniformBindGroup() {
         return this._uniformBindGroup;
     }
 
-    get compiledShaders(){
+    get compiledShaders() {
         return this._compiledShaders;
     }
 }
@@ -649,7 +649,7 @@ export default class Points {
         this.addUniform(UniformKeys.MOUSE_DELTA_X, this._mouseDeltaX);
         this.addUniform(UniformKeys.MOUSE_DELTA_Y, this._mouseDeltaY);
 
-        this._renderPasses.forEach( (renderPass, index) => {
+        this._renderPasses.forEach((renderPass, index) => {
             let vertexShader = renderPass.vertexShader;
             let computeShader = renderPass.computeShader;
             let fragmentShader = renderPass.fragmentShader;
@@ -930,7 +930,7 @@ export default class Points {
     }
 
     _createComputeBindGroup() {
-        this._renderPasses.forEach( (renderPass, index) => {
+        this._renderPasses.forEach((renderPass, index) => {
 
             const entries = this._createEntries(ShaderType.COMPUTE);
             if (entries.length) {
@@ -941,14 +941,14 @@ export default class Points {
                         binding: index,
                         visibility: GPUShaderStage.COMPUTE
                     }
-                    bglEntry[entry.type.name] = {'type': entry.type.type};
-                    if(entry.type.format){
+                    bglEntry[entry.type.name] = { 'type': entry.type.type };
+                    if (entry.type.format) {
                         bglEntry[entry.type.name].format = entry.type.format
                     }
                     bglEntries.push(bglEntry);
                 });
 
-                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
+                renderPass.bindGroupLayout = this._device.createBindGroupLayout({ entries: bglEntries });
 
                 /**
                  * @type {GPUBindGroup}
@@ -967,7 +967,7 @@ export default class Points {
 
         this._createComputeBindGroup();
 
-        this._renderPasses.forEach( (renderPass, index) => {
+        this._renderPasses.forEach((renderPass, index) => {
             renderPass.computePipeline = this._device.createComputePipeline({
                 layout: this._device.createPipelineLayout({
                     bindGroupLayouts: [renderPass.bindGroupLayout]
@@ -1254,18 +1254,25 @@ export default class Points {
                 entries.forEach((entry, index) => {
                     let bglEntry = {
                         binding: index,
-                        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT
+                        visibility: GPUShaderStage.FRAGMENT
                     }
 
-                    // apparently it throws an error if we use buffer in FRAGMENT
-                    // TODO: pre filter this in the ENTRIES array
-                    if(entry.name != 'buffer'){
-                        bglEntry[entry.type.name] = {'type': entry.type.type};
+                    bglEntry[entry.type.name] = { 'type': entry.type.type };
+
+                    // TODO: 1262
+                    // if you remove this there's an error that I think is not explained right
+                    // it talks about a storage in index 1 but it was actually the 0
+                    // and so is to this uniform you have to change the visibility
+                    // not remove the type and leaving it empty as it seems you have to do here:
+                    // https://gpuweb.github.io/gpuweb/#bindgroup-examples
+                    if (entry.type.type == 'uniform') {
+                        bglEntry.visibility = GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT
                     }
+
                     bglEntries.push(bglEntry);
                 });
 
-                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
+                renderPass.bindGroupLayout = this._device.createBindGroupLayout({ entries: bglEntries });
 
                 renderPass.uniformBindGroup = this._device.createBindGroup({
                     label: '_createParams() 0',

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -46,6 +46,9 @@ export class RenderPass {
         this._computeBindGroups = null;
         this._computeBindGroups2 = null;
 
+        this._uniformBindGroup = null;
+        this._uniformBindGroup2 = null;
+
         this._compiledShaders = {
             vertex: '',
             compute: '',
@@ -95,6 +98,22 @@ export class RenderPass {
 
     get computeBindGroups2(){
         return this._computeBindGroups;
+    }
+
+    set uniformBindGroup(value){
+        this._uniformBindGroup = value;
+    }
+
+    get uniformBindGroup(){
+        return this._uniformBindGroup;
+    }
+
+    set uniformBindGroup2(value){
+        this._uniformBindGroup2 = value;
+    }
+
+    get uniformBindGroup2(){
+        return this._uniformBindGroup2;
     }
 
     get compiledShaders(){
@@ -150,8 +169,8 @@ export default class Points {
         // this._useTexture = false;
         // this._shaders = [];
         this._renderPasses = null;
-        this._pipeline = null;
-        this._computePipeline = null;
+        // this._pipeline = null;
+        // this._computePipeline = null;
         this._vertexBufferInfo = null;
         this._buffer = null;
 
@@ -162,7 +181,6 @@ export default class Points {
         this._commandEncoder = null;
 
         this._vertexArray = [];
-        this._gpuBufferFirstMatrix = [];
 
         this._numColumns = 1;
         this._numRows = 1;
@@ -1294,9 +1312,9 @@ export default class Points {
             //---------------------------------------
             const passEncoder = commandEncoder.beginRenderPass(this._renderPassDescriptor);
             passEncoder.setPipeline(this._renderPasses[0].renderPipeline);
-            if (this._useTexture) {
-                passEncoder.setBindGroup(0, this._uniformBindGroup);
-            }
+            // if (this._useTexture) {
+            //     passEncoder.setBindGroup(0, this._uniformBindGroup);
+            // }
 
             this._createParams();
             passEncoder.setBindGroup(0, this._uniformBindGroup);
@@ -1435,20 +1453,20 @@ export default class Points {
         return this._buffer;
     }
 
-    /**
-     * @param {Boolean} value
-     */
-    set useTexture(value) {
-        this._useTexture = value;
-    }
+    // /**
+    //  * @param {Boolean} value
+    //  */
+    // set useTexture(value) {
+    //     this._useTexture = value;
+    // }
 
-    get useTexture() {
-        return this._useTexture;
-    }
+    // get useTexture() {
+    //     return this._useTexture;
+    // }
 
-    get pipeline() {
-        return this._pipeline;
-    }
+    // get pipeline() {
+    //     return this._pipeline;
+    // }
 
     get fullscreen() {
         return this._fullscreen;

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -1309,7 +1309,7 @@ export default class Points {
 
 
         //commandEncoder = this._device.createCommandEncoder();
-        this._renderPasses.forEach(renderPass =>         {
+        this._renderPasses.forEach(renderPass => {
             //---------------------------------------
             const passEncoder = commandEncoder.beginRenderPass(this._renderPassDescriptor);
             passEncoder.setPipeline(renderPass.renderPipeline);
@@ -1333,24 +1333,26 @@ export default class Points {
             //passEncoder.draw(3, 1, 0, 0);
             passEncoder.draw(this._vertexBufferInfo.vertexCount);
             passEncoder.end();
+
+            // Copy the rendering results from the swapchain into |texture2d.texture|.
+
+            this._textures2d.forEach(texture2d => {
+                if (texture2d.copyCurrentTexture) {
+                    commandEncoder.copyTextureToTexture(
+                        {
+                            texture: swapChainTexture,
+                        },
+                        {
+                            texture: texture2d.texture,
+                        },
+                        this._presentationSize
+                    );
+                }
+            });
         });
 
 
-        // Copy the rendering results from the swapchain into |cubeTexture|.
 
-        this._textures2d.forEach(texture2d => {
-            if (texture2d.copyCurrentTexture) {
-                commandEncoder.copyTextureToTexture(
-                    {
-                        texture: swapChainTexture,
-                    },
-                    {
-                        texture: texture2d.texture,
-                    },
-                    this._presentationSize
-                );
-            }
-        })
 
         if (this._readStorage.length && !this._readStorageCopied) {
             this._readStorage.forEach(readStorageItem => {

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -323,7 +323,6 @@ export default class Points {
         variable.value = value;
     }
 
-
     /**
      * Creates a persistent memory buffer across every frame call.
      * @param {string} name Name that the Storage will have in the shader
@@ -355,8 +354,6 @@ export default class Points {
             }
             this._readStorage.push(storageItem);
         }
-
-
     }
 
     addStorageMap(name, arrayData, structName, shaderType) {
@@ -727,14 +724,6 @@ export default class Points {
             console.log(colorsFragWGSL);
             console.groupEnd();
             console.groupEnd();
-
-            // this._shaders.push(
-            //     {
-            //         vertex: colorsVertWGSL,
-            //         compute: colorsComputeWGSL,
-            //         fragment: colorsFragWGSL
-            //     }
-            // );
 
             renderPass.compiledShaders.vertex = colorsVertWGSL;
             renderPass.compiledShaders.compute = colorsComputeWGSL;
@@ -1363,16 +1352,6 @@ export default class Points {
             }
         })
 
-        // commandEncoder.copyTextureToTexture(
-        //     {
-        //         texture: swapChainTexture,
-        //     },
-        //     {
-        //         texture: this._feedbackLoopTexture,
-        //     },
-        //     this._presentationSize
-        // );
-
         if (this._readStorage.length && !this._readStorageCopied) {
             this._readStorage.forEach(readStorageItem => {
                 let storageItem = this._storage.find(storageItem => storageItem.name === readStorageItem.name);
@@ -1465,21 +1444,6 @@ export default class Points {
     get buffer() {
         return this._buffer;
     }
-
-    // /**
-    //  * @param {Boolean} value
-    //  */
-    // set useTexture(value) {
-    //     this._useTexture = value;
-    // }
-
-    // get useTexture() {
-    //     return this._useTexture;
-    // }
-
-    // get pipeline() {
-    //     return this._pipeline;
-    // }
 
     get fullscreen() {
         return this._fullscreen;

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -934,12 +934,26 @@ export default class Points {
 
             const entries = this._createEntries(ShaderType.COMPUTE);
             if (entries.length) {
+
+                let bglEntries = [];
+                entries.forEach((entry, index) => {
+                    let bglEntry = {
+                        binding: index,
+                        visibility: GPUShaderStage.COMPUTE
+                    }
+                    bglEntry[entry.type.name] = {'type': entry.type.type};
+                    bglEntries.push(bglEntry);
+                });
+                // console.log(bglEntries);
+                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries})
+
                 /**
                  * @type {GPUBindGroup}
                  */
                 renderPass.computeBindGroup = this._device.createBindGroup({
                     label: `_createComputeBindGroup 0 - ${index}`,
-                    layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
+                    // layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
+                    layout: renderPass.bindGroupLayout,
                     entries: entries
                 });
             }
@@ -948,13 +962,15 @@ export default class Points {
 
     async createPipeline() {
 
+        this._createComputeBindGroup();
+
         this._renderPasses.forEach( (renderPass, index) => {
             renderPass.computePipeline = this._device.createComputePipeline({
-                /*layout: device.createPipelineLayout({
-                    bindGroupLayouts: [bindGroupLayout]
-                }),*/
+                layout: this._device.createPipelineLayout({
+                    bindGroupLayouts: [renderPass.bindGroupLayout]
+                }),
                 label: `createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER? - ${index}`,
-                layout: 'auto',
+                // layout: 'auto',
                 compute: {
                     module: this._device.createShaderModule({
                         code: renderPass.compiledShaders.compute
@@ -964,7 +980,6 @@ export default class Points {
             });
         });
 
-        this._createComputeBindGroup();
 
         //--------------------------------------
 
@@ -1069,6 +1084,10 @@ export default class Points {
                     resource: {
                         label: 'uniform',
                         buffer: this._uniforms.buffer
+                    },
+                    type: {
+                        name: 'buffer',
+                        type: 'uniform'
                     }
                 }
             );
@@ -1083,6 +1102,10 @@ export default class Points {
                             resource: {
                                 label: 'storage',
                                 buffer: storageItem.buffer
+                            },
+                            type: {
+                                name: 'buffer',
+                                type: 'storage'
                             }
                         }
                     );
@@ -1098,6 +1121,10 @@ export default class Points {
                         resource: {
                             label: 'layer',
                             buffer: this._layers.buffer
+                        },
+                        type: {
+                            name: 'buffer',
+                            type: 'storage'
                         }
                     }
                 );
@@ -1110,7 +1137,11 @@ export default class Points {
                     entries.push(
                         {
                             binding: bindingIndex++,
-                            resource: sampler.resource
+                            resource: sampler.resource,
+                            type: {
+                                name: 'sampler',
+                                type: 'filtering'
+                            }
                         }
                     );
                 }
@@ -1124,7 +1155,11 @@ export default class Points {
                         {
                             label: 'texture storage 2d',
                             binding: bindingIndex++,
-                            resource: textureStorage2d.texture.createView()
+                            resource: textureStorage2d.texture.createView(),
+                            type: {
+                                name: 'storageTexture',
+                                type: 'write-only'
+                            }
                         }
                     );
                 }
@@ -1138,7 +1173,11 @@ export default class Points {
                         {
                             label: 'texture 2d',
                             binding: bindingIndex++,
-                            resource: texture2d.texture.createView()
+                            resource: texture2d.texture.createView(),
+                            type: {
+                                name: 'texture',
+                                type: 'float'
+                            }
                         }
                     );
                 }
@@ -1152,7 +1191,11 @@ export default class Points {
                         {
                             label: 'external texture',
                             binding: bindingIndex++,
-                            resource: externalTexture.texture
+                            resource: externalTexture.texture,
+                            type: {
+                                name: 'externalTexture',
+                                type: 'write-only'
+                            }
                         }
                     );
                 }
@@ -1166,7 +1209,11 @@ export default class Points {
                         {
                             label: 'binding texture',
                             binding: bindingIndex++,
-                            resource: bindingTexture.texture.createView()
+                            resource: bindingTexture.texture.createView(),
+                            type: {
+                                name: 'texture',
+                                type: 'float'
+                            }
                         }
                     );
                 }
@@ -1178,7 +1225,11 @@ export default class Points {
                         {
                             label: 'binding texture 2',
                             binding: bindingIndex, // this does not increase, must match the previous block
-                            resource: bindingTexture.texture.createView()
+                            resource: bindingTexture.texture.createView(),
+                            type: {
+                                name: 'texture',
+                                type: 'float'
+                            }
                         }
                     );
                 }

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -27,6 +27,33 @@ class UniformKeys {
     static MOUSE_DELTA_Y = 'mouseDeltaY';
 }
 
+export class RenderPass {
+    /**
+     * A collection of Vertex, Compute and Fragment shaders that represent a RenderPass.
+     * This is useful for PostProcessing.
+     * @param {String} vertexShader  WGSL Vertex Shader in a String.
+     * @param {String} computeShader  WGSL Compute Shader in a String.
+     * @param {String} fragmentShader  WGSL Fragment Shader in a String.
+     */
+    constructor(vertexShader, computeShader, fragmentShader){
+        this._vertexShader = vertexShader;
+        this._computeShader = computeShader;
+        this._fragmentShader = fragmentShader;
+    }
+
+    get vertexShader(){
+        return this._vertexShader;
+    }
+
+    get computeShader(){
+        return this._computeShader;
+    }
+
+    get fragmentShader(){
+        return this._fragmentShader;
+    }
+}
+
 export class VertexBufferInfo {
     /**
      * Along with the vertexArray it calculates some info like offsets required for the pipeline.
@@ -563,14 +590,14 @@ export default class Points {
 
     /**
      * One time function to call to initialize the shaders.
-     * @param {String} vertexShader WGSL Vertex Shader in a String.
-     * @param {String} computeShader WGSL Compute Shader in a String.
-     * @param {String} fragmentShader WGSL Fragment Shader in a String.
-     * @param {Number} numColumns Number of columns in the base mesh.
-     * @param {Number} numRows Number of rows in the base mesh.
+     * @param {array<RenderPass>} renderPasses Collection of RenderPass, which contain Vertex, Compute and Fragment shaders.
      * @returns false | undefined
      */
-    async init(vertexShader, computeShader, fragmentShader) {
+    async init(renderPasses) {
+
+        let vertexShader = renderPasses[0].vertexShader;
+        let computeShader = renderPasses[0].computeShader;
+        let fragmentShader = renderPasses[0].fragmentShader;
 
         // initializing internal uniforms
         this.addUniform(UniformKeys.TIME, this._time);

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -93,11 +93,11 @@ export class RenderPass {
     }
 
     set computeBindGroups2(value){
-        this._computeBindGroups = value;
+        this._computeBindGroups2 = value;
     }
 
     get computeBindGroups2(){
-        return this._computeBindGroups;
+        return this._computeBindGroups2;
     }
 
     set uniformBindGroup(value){
@@ -174,8 +174,8 @@ export default class Points {
         this._vertexBufferInfo = null;
         this._buffer = null;
 
-        this._uniformBindGroup = null;
-        this._computeBindGroups = null;
+        // this._uniformBindGroup = null;
+        // this._computeBindGroups = null;
         this._presentationSize = null;
         this._depthTexture = null;
         this._commandEncoder = null;
@@ -966,12 +966,12 @@ export default class Points {
     }
 
     _createComputeBindGroup() {
-        this._renderPasses.forEach(renderPass => {
+        this._renderPasses.forEach( (renderPass, index) => {
             /**
              * @type {GPUBindGroup}
              */
-            this._computeBindGroups = this._device.createBindGroup({
-                label: '_createComputeBindGroup 0',
+            renderPass.computeBindGroups = this._device.createBindGroup({
+                label: `_createComputeBindGroup 0 - ${index}`,
                 layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
                 entries: [
                 ]
@@ -979,8 +979,8 @@ export default class Points {
 
             const entries = this._createEntries(ShaderType.COMPUTE);
             if (entries.length) {
-                this._computeBindGroups2 = this._device.createBindGroup({
-                    label: '_createComputeBindGroup 1',
+                renderPass.computeBindGroups2 = this._device.createBindGroup({
+                    label: `_createComputeBindGroup 1 - ${index}`,
                     layout: renderPass.computePipeline.getBindGroupLayout(1 /* index */),
                     entries: entries
                 });
@@ -991,12 +991,12 @@ export default class Points {
     async createPipeline() {
 
         // this._computePipeline = this._device.createComputePipeline({
-        this._renderPasses.forEach(renderPass => {
+        this._renderPasses.forEach( (renderPass, index) => {
             renderPass.computePipeline = this._device.createComputePipeline({
                 /*layout: device.createPipelineLayout({
                     bindGroupLayouts: [bindGroupLayout]
                 }),*/
-                label: 'createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER?',
+                label: `createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER? - ${index}`,
                 layout: 'auto',
                 compute: {
                     module: this._device.createShaderModule({
@@ -1233,7 +1233,7 @@ export default class Points {
 
     _createParams() {
         this._renderPasses.forEach(renderPass => {
-            this._uniformBindGroup = this._device.createBindGroup({
+            renderPass.uniformBindGroup = this._device.createBindGroup({
                 label: '_createParams() 0',
                 layout: renderPass.renderPipeline.getBindGroupLayout(0),
                 entries: [
@@ -1242,7 +1242,7 @@ export default class Points {
 
             const entries = this._createEntries(ShaderType.FRAGMENT);
             if (entries.length) {
-                this._uniformBindGroup2 = this._device.createBindGroup({
+                renderPass.uniformBindGroup2 = this._device.createBindGroup({
                     label: '_createParams() 1',
                     layout: renderPass.renderPipeline.getBindGroupLayout(1 /* index */),
                     entries: entries
@@ -1298,9 +1298,9 @@ export default class Points {
         this._renderPasses.forEach(renderPass => {
             const passEncoder = commandEncoder.beginComputePass();
             passEncoder.setPipeline(renderPass.computePipeline);
-            passEncoder.setBindGroup(0, this._computeBindGroups);
+            passEncoder.setBindGroup(0, renderPass.computeBindGroups);
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(1, this._computeBindGroups2);
+                passEncoder.setBindGroup(1, renderPass.computeBindGroups2);
             }
             passEncoder.dispatchWorkgroups(8, 8, 1);
             passEncoder.end();
@@ -1329,9 +1329,9 @@ export default class Points {
             // }
 
             this._createParams();
-            passEncoder.setBindGroup(0, this._uniformBindGroup);
+            passEncoder.setBindGroup(0, renderPass.uniformBindGroup);
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(1, this._uniformBindGroup2);
+                passEncoder.setBindGroup(1, renderPass.uniformBindGroup2);
             }
             passEncoder.setVertexBuffer(0, this._buffer);
 

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -43,8 +43,8 @@ export class RenderPass {
         this._computePipeline = null;
         this._renderPipeline = null;
 
-        this._computeBindGroups2 = null;
-        this._uniformBindGroup2 = null;
+        this._computeBindGroup = null;
+        this._uniformBindGroup = null;
 
         this._compiledShaders = {
             vertex: '',
@@ -81,20 +81,20 @@ export class RenderPass {
         return this._renderPipeline;
     }
 
-    set computeBindGroups2(value){
-        this._computeBindGroups2 = value;
+    set computeBindGroup(value){
+        this._computeBindGroup = value;
     }
 
-    get computeBindGroups2(){
-        return this._computeBindGroups2;
+    get computeBindGroup(){
+        return this._computeBindGroup;
     }
 
-    set uniformBindGroup2(value){
-        this._uniformBindGroup2 = value;
+    set uniformBindGroup(value){
+        this._uniformBindGroup = value;
     }
 
-    get uniformBindGroup2(){
-        return this._uniformBindGroup2;
+    get uniformBindGroup(){
+        return this._uniformBindGroup;
     }
 
     get compiledShaders(){
@@ -937,7 +937,7 @@ export default class Points {
                 /**
                  * @type {GPUBindGroup}
                  */
-                renderPass.computeBindGroups2 = this._device.createBindGroup({
+                renderPass.computeBindGroup = this._device.createBindGroup({
                     label: `_createComputeBindGroup 1 - ${index}`,
                     layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
@@ -1193,7 +1193,7 @@ export default class Points {
 
             const entries = this._createEntries(ShaderType.FRAGMENT);
             if (entries.length) {
-                renderPass.uniformBindGroup2 = this._device.createBindGroup({
+                renderPass.uniformBindGroup = this._device.createBindGroup({
                     label: '_createParams() 1',
                     layout: renderPass.renderPipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
@@ -1250,7 +1250,7 @@ export default class Points {
             const passEncoder = commandEncoder.beginComputePass();
             passEncoder.setPipeline(renderPass.computePipeline);
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(0, renderPass.computeBindGroups2);
+                passEncoder.setBindGroup(0, renderPass.computeBindGroup);
             }
             passEncoder.dispatchWorkgroups(8, 8, 1);
             passEncoder.end();
@@ -1277,7 +1277,7 @@ export default class Points {
 
             this._createParams();
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(0, renderPass.uniformBindGroup2);
+                passEncoder.setBindGroup(0, renderPass.uniformBindGroup);
             }
             passEncoder.setVertexBuffer(0, this._buffer);
 

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -938,7 +938,7 @@ export default class Points {
                  * @type {GPUBindGroup}
                  */
                 renderPass.computeBindGroup = this._device.createBindGroup({
-                    label: `_createComputeBindGroup 1 - ${index}`,
+                    label: `_createComputeBindGroup 0 - ${index}`,
                     layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
                 });
@@ -1194,7 +1194,7 @@ export default class Points {
             const entries = this._createEntries(ShaderType.FRAGMENT);
             if (entries.length) {
                 renderPass.uniformBindGroup = this._device.createBindGroup({
-                    label: '_createParams() 1',
+                    label: '_createParams() 0',
                     layout: renderPass.renderPipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
                 });

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -945,7 +945,7 @@ export default class Points {
                     bglEntries.push(bglEntry);
                 });
                 // console.log(bglEntries);
-                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries})
+                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
 
                 /**
                  * @type {GPUBindGroup}
@@ -970,7 +970,6 @@ export default class Points {
                     bindGroupLayouts: [renderPass.bindGroupLayout]
                 }),
                 label: `createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER? - ${index}`,
-                // layout: 'auto',
                 compute: {
                     module: this._device.createShaderModule({
                         code: renderPass.compiledShaders.compute
@@ -984,6 +983,8 @@ export default class Points {
         //--------------------------------------
 
 
+        this._createParams();
+
         //this.createVertexBuffer(new Float32Array(this._vertexArray));
         // enum GPUPrimitiveTopology {
         //     'point-list',
@@ -995,8 +996,10 @@ export default class Points {
         this._renderPasses.forEach(renderPass => {
 
             renderPass.renderPipeline = this._device.createRenderPipeline({
-                layout: 'auto',
-                //layout: bindGroupLayout,
+                // layout: 'auto',
+                layout: this._device.createPipelineLayout({
+                    bindGroupLayouts: [renderPass.bindGroupLayout]
+                }),
                 //primitive: { topology: 'triangle-strip' },
                 primitive: { topology: 'triangle-list' },
                 depthStencil: {
@@ -1066,8 +1069,6 @@ export default class Points {
             });
         });
 
-
-        this._createParams();
     }
 
     /**
@@ -1244,9 +1245,22 @@ export default class Points {
 
             const entries = this._createEntries(ShaderType.FRAGMENT);
             if (entries.length) {
+
+                let bglEntries = [];
+                entries.forEach((entry, index) => {
+                    let bglEntry = {
+                        binding: index,
+                        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT
+                    }
+                    bglEntry[entry.type.name] = {'type': entry.type.type};
+                    bglEntries.push(bglEntry);
+                });
+                // console.log(bglEntries);
+                renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
+
                 renderPass.uniformBindGroup = this._device.createBindGroup({
                     label: '_createParams() 0',
-                    layout: renderPass.renderPipeline.getBindGroupLayout(0 /* index */),
+                    layout: renderPass.bindGroupLayout,
                     entries: entries
                 });
             }

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -942,9 +942,12 @@ export default class Points {
                         visibility: GPUShaderStage.COMPUTE
                     }
                     bglEntry[entry.type.name] = {'type': entry.type.type};
+                    if(entry.type.format){
+                        bglEntry[entry.type.name].format = entry.type.format
+                    }
                     bglEntries.push(bglEntry);
                 });
-                // console.log(bglEntries);
+
                 renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
 
                 /**
@@ -1195,7 +1198,7 @@ export default class Points {
                             resource: externalTexture.texture,
                             type: {
                                 name: 'externalTexture',
-                                type: 'write-only'
+                                // type: 'write-only'
                             }
                         }
                     );
@@ -1212,8 +1215,9 @@ export default class Points {
                             binding: bindingIndex++,
                             resource: bindingTexture.texture.createView(),
                             type: {
-                                name: 'texture',
-                                type: 'float'
+                                name: 'storageTexture',
+                                type: 'write-only',
+                                format: 'rgba8unorm'
                             }
                         }
                     );
@@ -1252,10 +1256,15 @@ export default class Points {
                         binding: index,
                         visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT
                     }
-                    bglEntry[entry.type.name] = {'type': entry.type.type};
+
+                    // apparently it throws an error if we use buffer in FRAGMENT
+                    // TODO: pre filter this in the ENTRIES array
+                    if(entry.name != 'buffer'){
+                        bglEntry[entry.type.name] = {'type': entry.type.type};
+                    }
                     bglEntries.push(bglEntry);
                 });
-                // console.log(bglEntries);
+
                 renderPass.bindGroupLayout = this._device.createBindGroupLayout({entries: bglEntries});
 
                 renderPass.uniformBindGroup = this._device.createBindGroup({

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -43,6 +43,9 @@ export class RenderPass {
         this._computePipeline = null;
         this._renderPipeline = null;
 
+        this._computeBindGroups = null;
+        this._computeBindGroups2 = null;
+
         this._compiledShaders = {
             vertex: '',
             compute: '',
@@ -76,6 +79,22 @@ export class RenderPass {
 
     get renderPipeline(){
         return this._renderPipeline;
+    }
+
+    set computeBindGroups(value){
+        this._computeBindGroups = value;
+    }
+
+    get computeBindGroups(){
+        return this._computeBindGroups;
+    }
+
+    set computeBindGroups2(value){
+        this._computeBindGroups = value;
+    }
+
+    get computeBindGroups2(){
+        return this._computeBindGroups;
     }
 
     get compiledShaders(){

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -966,41 +966,45 @@ export default class Points {
     }
 
     _createComputeBindGroup() {
-        /**
-         * @type {GPUBindGroup}
-         */
-        this._computeBindGroups = this._device.createBindGroup({
-            label: '_createComputeBindGroup 0',
-            layout: this._renderPasses[0].computePipeline.getBindGroupLayout(0 /* index */),
-            entries: [
-            ]
-        });
-
-        const entries = this._createEntries(ShaderType.COMPUTE);
-        if (entries.length) {
-            this._computeBindGroups2 = this._device.createBindGroup({
-                label: '_createComputeBindGroup 1',
-                layout: this._renderPasses[0].computePipeline.getBindGroupLayout(1 /* index */),
-                entries: entries
+        this._renderPasses.forEach(renderPass => {
+            /**
+             * @type {GPUBindGroup}
+             */
+            this._computeBindGroups = this._device.createBindGroup({
+                label: '_createComputeBindGroup 0',
+                layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
+                entries: [
+                ]
             });
-        }
+
+            const entries = this._createEntries(ShaderType.COMPUTE);
+            if (entries.length) {
+                this._computeBindGroups2 = this._device.createBindGroup({
+                    label: '_createComputeBindGroup 1',
+                    layout: renderPass.computePipeline.getBindGroupLayout(1 /* index */),
+                    entries: entries
+                });
+            }
+        });
     }
 
     async createPipeline() {
 
         // this._computePipeline = this._device.createComputePipeline({
-        this._renderPasses[0].computePipeline = this._device.createComputePipeline({
-            /*layout: device.createPipelineLayout({
-                bindGroupLayouts: [bindGroupLayout]
-            }),*/
-            label: 'createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER?',
-            layout: 'auto',
-            compute: {
-                module: this._device.createShaderModule({
-                    code: this._renderPasses[0].compiledShaders.compute
-                }),
-                entryPoint: "main"
-            }
+        this._renderPasses.forEach(renderPass => {
+            renderPass.computePipeline = this._device.createComputePipeline({
+                /*layout: device.createPipelineLayout({
+                    bindGroupLayouts: [bindGroupLayout]
+                }),*/
+                label: 'createPipeline(): DID YOU CALL THE VARIABLE IN THE SHADER?',
+                layout: 'auto',
+                compute: {
+                    module: this._device.createShaderModule({
+                        code: renderPass.compiledShaders.compute
+                    }),
+                    entryPoint: "main"
+                }
+            });
         });
 
         this._createComputeBindGroup();
@@ -1016,76 +1020,80 @@ export default class Points {
         //     'triangle-list',
         //     'triangle-strip',
         // };
-        this._renderPasses[0].renderPipeline = this._device.createRenderPipeline({
-            layout: 'auto',
-            //layout: bindGroupLayout,
-            //primitive: { topology: 'triangle-strip' },
-            primitive: { topology: 'triangle-list' },
-            depthStencil: {
-                depthWriteEnabled: true,
-                depthCompare: 'less',
-                format: 'depth24plus',
-            },
-            vertex: {
-                module: this._device.createShaderModule({
-                    code: this._renderPasses[0].compiledShaders.vertex,
-                }),
-                entryPoint: 'main', // shader function name
+        this._renderPasses.forEach(renderPass => {
 
-                buffers: [
-                    {
-                        arrayStride: this._vertexBufferInfo.vertexSize,
-                        attributes: [
-                            {
-                                // position
-                                shaderLocation: 0,
-                                offset: this._vertexBufferInfo.vertexOffset,
-                                format: 'float32x4',
-                            },
-                            {
-                                // colors
-                                shaderLocation: 1,
-                                offset: this._vertexBufferInfo.colorOffset,
-                                format: 'float32x4',
-                            },
-                            {
-                                // uv
-                                shaderLocation: 2,
-                                offset: this._vertexBufferInfo.uvOffset,
-                                format: 'float32x2',
-                            },
-                        ],
-                    },
-                ],
-            },
-            fragment: {
-                module: this._device.createShaderModule({
-                    code: this._renderPasses[0].compiledShaders.fragment,
-                }),
-                entryPoint: 'main', // shader function name
-                targets: [
-                    {
-                        format: this._presentationFormat,
+            renderPass.renderPipeline = this._device.createRenderPipeline({
+                layout: 'auto',
+                //layout: bindGroupLayout,
+                //primitive: { topology: 'triangle-strip' },
+                primitive: { topology: 'triangle-list' },
+                depthStencil: {
+                    depthWriteEnabled: true,
+                    depthCompare: 'less',
+                    format: 'depth24plus',
+                },
+                vertex: {
+                    module: this._device.createShaderModule({
+                        code: renderPass.compiledShaders.vertex,
+                    }),
+                    entryPoint: 'main', // shader function name
 
-                        blend: {
-                            alpha: {
-                                srcFactor: 'src-alpha',
-                                dstFactor: 'one-minus-src-alpha',
-                                operation: 'add'
-                            },
-                            color: {
-                                srcFactor: 'src-alpha',
-                                dstFactor: 'one-minus-src-alpha',
-                                operation: 'add'
-                            },
+                    buffers: [
+                        {
+                            arrayStride: this._vertexBufferInfo.vertexSize,
+                            attributes: [
+                                {
+                                    // position
+                                    shaderLocation: 0,
+                                    offset: this._vertexBufferInfo.vertexOffset,
+                                    format: 'float32x4',
+                                },
+                                {
+                                    // colors
+                                    shaderLocation: 1,
+                                    offset: this._vertexBufferInfo.colorOffset,
+                                    format: 'float32x4',
+                                },
+                                {
+                                    // uv
+                                    shaderLocation: 2,
+                                    offset: this._vertexBufferInfo.uvOffset,
+                                    format: 'float32x2',
+                                },
+                            ],
                         },
-                        writeMask: GPUColorWrite.ALL,
+                    ],
+                },
+                fragment: {
+                    module: this._device.createShaderModule({
+                        code: renderPass.compiledShaders.fragment,
+                    }),
+                    entryPoint: 'main', // shader function name
+                    targets: [
+                        {
+                            format: this._presentationFormat,
 
-                    },
-                ],
-            },
+                            blend: {
+                                alpha: {
+                                    srcFactor: 'src-alpha',
+                                    dstFactor: 'one-minus-src-alpha',
+                                    operation: 'add'
+                                },
+                                color: {
+                                    srcFactor: 'src-alpha',
+                                    dstFactor: 'one-minus-src-alpha',
+                                    operation: 'add'
+                                },
+                            },
+                            writeMask: GPUColorWrite.ALL,
 
+                        },
+                    ],
+                },
+
+            });
         });
+
 
         this._createParams();
     }
@@ -1224,21 +1232,23 @@ export default class Points {
     }
 
     _createParams() {
-        this._uniformBindGroup = this._device.createBindGroup({
-            label: '_createParams() 0',
-            layout: this._renderPasses[0].renderPipeline.getBindGroupLayout(0),
-            entries: [
-            ],
-        });
-
-        const entries = this._createEntries(ShaderType.FRAGMENT);
-        if (entries.length) {
-            this._uniformBindGroup2 = this._device.createBindGroup({
-                label: '_createParams() 1',
-                layout: this._renderPasses[0].renderPipeline.getBindGroupLayout(1 /* index */),
-                entries: entries
+        this._renderPasses.forEach(renderPass => {
+            this._uniformBindGroup = this._device.createBindGroup({
+                label: '_createParams() 0',
+                layout: renderPass.renderPipeline.getBindGroupLayout(0),
+                entries: [
+                ],
             });
-        }
+
+            const entries = this._createEntries(ShaderType.FRAGMENT);
+            if (entries.length) {
+                this._uniformBindGroup2 = this._device.createBindGroup({
+                    label: '_createParams() 1',
+                    layout: renderPass.renderPipeline.getBindGroupLayout(1 /* index */),
+                    entries: entries
+                });
+            }
+        });
 
     }
 
@@ -1285,15 +1295,17 @@ export default class Points {
         let commandEncoder = this._device.createCommandEncoder();
 
 
+        this._renderPasses.forEach(renderPass => {
+            const passEncoder = commandEncoder.beginComputePass();
+            passEncoder.setPipeline(renderPass.computePipeline);
+            passEncoder.setBindGroup(0, this._computeBindGroups);
+            if (this._uniforms.length) {
+                passEncoder.setBindGroup(1, this._computeBindGroups2);
+            }
+            passEncoder.dispatchWorkgroups(8, 8, 1);
+            passEncoder.end();
+        });
 
-        const passEncoder = commandEncoder.beginComputePass();
-        passEncoder.setPipeline(this._renderPasses[0].computePipeline);
-        passEncoder.setBindGroup(0, this._computeBindGroups);
-        if (this._uniforms.length) {
-            passEncoder.setBindGroup(1, this._computeBindGroups2);
-        }
-        passEncoder.dispatchWorkgroups(8, 8, 1);
-        passEncoder.end();
 
         // ---------------------
 
@@ -1308,10 +1320,10 @@ export default class Points {
 
 
         //commandEncoder = this._device.createCommandEncoder();
-        {
+        this._renderPasses.forEach(renderPass =>         {
             //---------------------------------------
             const passEncoder = commandEncoder.beginRenderPass(this._renderPassDescriptor);
-            passEncoder.setPipeline(this._renderPasses[0].renderPipeline);
+            passEncoder.setPipeline(renderPass.renderPipeline);
             // if (this._useTexture) {
             //     passEncoder.setBindGroup(0, this._uniformBindGroup);
             // }
@@ -1332,7 +1344,8 @@ export default class Points {
             //passEncoder.draw(3, 1, 0, 0);
             passEncoder.draw(this._vertexBufferInfo.vertexCount);
             passEncoder.end();
-        }
+        });
+
 
         // Copy the rendering results from the swapchain into |cubeTexture|.
 

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -562,11 +562,11 @@ export default class Points {
         if (!shaderType) {
             throw '`ShaderType` is required';
         }
-        const groupId = 1;
+        const groupId = 0;
         let dynamicGroupBindings = '';
         let bindingIndex = 0;
         if (this._uniforms.length) {
-            dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(0) var <uniform> params: Params;\n`;
+            dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var <uniform> params: Params;\n`;
             bindingIndex += 1;
         }
 
@@ -956,21 +956,15 @@ export default class Points {
 
     _createComputeBindGroup() {
         this._renderPasses.forEach( (renderPass, index) => {
-            /**
-             * @type {GPUBindGroup}
-             */
-            renderPass.computeBindGroups = this._device.createBindGroup({
-                label: `_createComputeBindGroup 0 - ${index}`,
-                layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
-                entries: [
-                ]
-            });
 
             const entries = this._createEntries(ShaderType.COMPUTE);
             if (entries.length) {
+                /**
+                 * @type {GPUBindGroup}
+                 */
                 renderPass.computeBindGroups2 = this._device.createBindGroup({
                     label: `_createComputeBindGroup 1 - ${index}`,
-                    layout: renderPass.computePipeline.getBindGroupLayout(1 /* index */),
+                    layout: renderPass.computePipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
                 });
             }
@@ -1222,18 +1216,12 @@ export default class Points {
 
     _createParams() {
         this._renderPasses.forEach(renderPass => {
-            renderPass.uniformBindGroup = this._device.createBindGroup({
-                label: '_createParams() 0',
-                layout: renderPass.renderPipeline.getBindGroupLayout(0),
-                entries: [
-                ],
-            });
 
             const entries = this._createEntries(ShaderType.FRAGMENT);
             if (entries.length) {
                 renderPass.uniformBindGroup2 = this._device.createBindGroup({
                     label: '_createParams() 1',
-                    layout: renderPass.renderPipeline.getBindGroupLayout(1 /* index */),
+                    layout: renderPass.renderPipeline.getBindGroupLayout(0 /* index */),
                     entries: entries
                 });
             }
@@ -1287,9 +1275,8 @@ export default class Points {
         this._renderPasses.forEach(renderPass => {
             const passEncoder = commandEncoder.beginComputePass();
             passEncoder.setPipeline(renderPass.computePipeline);
-            passEncoder.setBindGroup(0, renderPass.computeBindGroups);
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(1, renderPass.computeBindGroups2);
+                passEncoder.setBindGroup(0, renderPass.computeBindGroups2);
             }
             passEncoder.dispatchWorkgroups(8, 8, 1);
             passEncoder.end();
@@ -1313,14 +1300,10 @@ export default class Points {
             //---------------------------------------
             const passEncoder = commandEncoder.beginRenderPass(this._renderPassDescriptor);
             passEncoder.setPipeline(renderPass.renderPipeline);
-            // if (this._useTexture) {
-            //     passEncoder.setBindGroup(0, this._uniformBindGroup);
-            // }
 
             this._createParams();
-            passEncoder.setBindGroup(0, renderPass.uniformBindGroup);
             if (this._uniforms.length) {
-                passEncoder.setBindGroup(1, renderPass.uniformBindGroup2);
+                passEncoder.setBindGroup(0, renderPass.uniformBindGroup2);
             }
             passEncoder.setVertexBuffer(0, this._buffer);
 

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -43,10 +43,7 @@ export class RenderPass {
         this._computePipeline = null;
         this._renderPipeline = null;
 
-        this._computeBindGroups = null;
         this._computeBindGroups2 = null;
-
-        this._uniformBindGroup = null;
         this._uniformBindGroup2 = null;
 
         this._compiledShaders = {
@@ -84,28 +81,12 @@ export class RenderPass {
         return this._renderPipeline;
     }
 
-    set computeBindGroups(value){
-        this._computeBindGroups = value;
-    }
-
-    get computeBindGroups(){
-        return this._computeBindGroups;
-    }
-
     set computeBindGroups2(value){
         this._computeBindGroups2 = value;
     }
 
     get computeBindGroups2(){
         return this._computeBindGroups2;
-    }
-
-    set uniformBindGroup(value){
-        this._uniformBindGroup = value;
-    }
-
-    get uniformBindGroup(){
-        return this._uniformBindGroup;
     }
 
     set uniformBindGroup2(value){
@@ -166,16 +147,10 @@ export default class Points {
         this._device = null;
         this._context = null;
         this._presentationFormat = null;
-        // this._useTexture = false;
-        // this._shaders = [];
         this._renderPasses = null;
-        // this._pipeline = null;
-        // this._computePipeline = null;
         this._vertexBufferInfo = null;
         this._buffer = null;
 
-        // this._uniformBindGroup = null;
-        // this._computeBindGroups = null;
         this._presentationSize = null;
         this._depthTexture = null;
         this._commandEncoder = null;
@@ -973,7 +948,6 @@ export default class Points {
 
     async createPipeline() {
 
-        // this._computePipeline = this._device.createComputePipeline({
         this._renderPasses.forEach( (renderPass, index) => {
             renderPass.computePipeline = this._device.createComputePipeline({
                 /*layout: device.createPipelineLayout({

--- a/src/core/color.js
+++ b/src/core/color.js
@@ -74,6 +74,9 @@ fn bloom(input:f32, iterations:i32, intensity:f32) -> f32 {
 }
 `;
 
+/**
+ * Special for letters and create an sdf version of a texture
+ */
 export const sdfSmooth = /*wgsl*/`
 fn sdfSmooth(color:vec4<f32>) -> vec4<f32> {
     var finalColor = color;


### PR DESCRIPTION
- Render passes allow for multiple blocks of shaders and apply effects like postprocessing
- Internally layouts are not explicit, this avoid the need of explicitly declaring the variables in the shaders even if not used with a dummy assignment
- General changes in documentation