### PR TITLE
Fix to compute not working in separate RenderPass

### DIFF
--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -843,7 +843,7 @@ export default class Points {
      * Adds two triangles called points per number of columns and rows
      */
     async createScreen() {
-        let hasVertexAndFragmentShader = this._renderPasses.every(renderPass => renderPass.hasVertexAndFragmentShader)
+        let hasVertexAndFragmentShader = this._renderPasses.some(renderPass => renderPass.hasVertexAndFragmentShader)
 
         if (hasVertexAndFragmentShader) {
             let colors = [


### PR DESCRIPTION
- If a Render pass with compute, fragment and vertex are split into two, one containing a compute and the rest in another, an error is shown because vertexbufferinfo is null, this could be fixed by creating a vertex buffer info in all render passes or with this some call instead of every, so now I will use the some call