### PR TITLE
Texture arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ https://github.com/Absulit/points/assets/233719/c7c164be-7b69-4277-a80c-ce458e75
     <a href="./examples/dithering2/">
         <img src="./docs/dithering2.png" alt="image with dithering effect 2" width="200"/>
     </a>
-    <a href="./examples/dithering3/">
-        <img src="./docs/dithering3.png" alt="image with dithering effect 2" width="200"/>
+    <a href="./examples/dithering3_1/">
+        <img src="./docs/dithering3.png" alt="image with dithering effect 3" width="200"/>
     </a>
     <a href="./examples/noise1/">
         <img src="./docs/noise1.png" alt="image with noise layered" width="200"/>

--- a/README.md
+++ b/README.md
@@ -492,6 +492,34 @@ let startPosition = vec2(.0);
 let rgbaImage = texturePosition(image, mySampler, startPosition, uv, false);
 ```
 
+## Texture2dArray - setTextureImageArray
+
+With `setTextureImageArray` you can send a list of images of the same dimensions to wgsl and access each one of them with an index.
+
+
+```js
+// main.js
+async function init() {
+    let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
+
+    const paths = ['./image1.jpg', './image2.jpg'];
+    // await since the resource is async we need to wait for it to be ready
+    await points.setTextureImageArray('images', paths); // texture array is named `images`
+
+    // more init code
+    await points.init(renderPasses);
+    update();
+}
+```
+
+
+```rust
+// frag.js
+// 0 is the index of image1.jpg, 1 is the index of image2.jpg
+let image1Color = textureSample(images, aSampler, imageUV, 0);
+let image2Color = textureSample(images, aSampler, imageUV, 1);
+```
+
 ## Storage - setStorage
 
 A storage is a large array with the same data type and this data can be modified at runtime inside the shaders, so in principle this is different to any other data type here where you can only send data and not modify it in the shaders, or as the uniforms where the data can only be updated from the JavaScript side. You can allocate this space and use it in the shaders and the data will remain in the next update/frame call.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ init();
 
 # RenderPass
 
-As shown before a `RenderPass` is a way to have a block of shaders to pass to your application pipeline and they will be executed in the order you pass them in the `Points.init()` method.
+As shown before a `RenderPass` is a way to have a block of shaders to pass to your application pipeline and these render passes will be executed in the order you pass them in the `Points.init()` method.
 
 ```js
 let renderPasses = [
@@ -292,7 +292,7 @@ let time = params.time;
 
 ### vert.js
 
-The vertex shader has this set of parameters set in the main function: position, color, uv, vertex_index.
+The vertex shader has this set of parameters initialized in the main function: position, color, uv, vertex_index.
 
 ```rust
 @vertex
@@ -307,7 +307,7 @@ fn main(
 }
 ```
 
-The `defaultVertexBody` returns a `Fragment` struct that provides the parameters for `frag.js` , it adds a ratio parameter with the ratio of the width and height of the canvas, and the mouse position as a `vec2<f32>` . The mouse position is different from the `params.mouse.x` and `params.mouse.y` , but it uses its values to calculate them in the UV space. The uv is ratio corrected, meaning that if your canvas is wider than taller, a portion of the uv will be out of bounds to mantain the aspect ratio. This might change later to a new uv[some name] to differentiate them, and still have the regular uv space to calculate the screen. Right now if you need to do that in a different canvas size rather than a 1:1 dimension, you have to use ratio to deconstruct the original value.
+The `defaultVertexBody` returns a `Fragment` struct that provides the parameters for `frag.js` , it adds a ratio parameter with the ratio of the width and height of the canvas, and the mouse position as a `vec2<f32>` . The mouse position is different from the `params.mouse.x` and `params.mouse.y` , but it uses its values to calculate them in the UV space. The uvr is ratio corrected, meaning that if your canvas is wider than taller, a portion of the uv will be out of bounds to mantain the aspect ratio.
 
 ```rust
 // defaultStructs.js
@@ -354,7 +354,7 @@ You can call one of the following methods, you pair the data with a `key` name, 
 
 ---
 
-> **Note:** all the `add*()` methods add the variables/buffers/data into all the shaders in all `RenderPass` passes.
+> **Note:** all the `set*()` methods add the variables/buffers/data into all the shaders in all `RenderPass` passes.
 
 ---
 
@@ -362,11 +362,6 @@ You can call one of the following methods, you pair the data with a `key` name, 
 
 Uniforms are sent separately in the `main.js` file and they are all combined in the shaders in the struct called `params` . By default, all values are `f32` if no Struct or Type is specified in the third parameter. If values have more than one dimension (`array`, `vec2f`, `vec3f`, `vec4f`...) the data has to be send as an array. Uniforms can not be modified at runtime inside the shaders, they can only receive data from the JavaScript side.
 
----
-
-> **Note:** structs as uniform types have very basic support and it will be fixed in later updates
-
----
 
 ```js
 // main.js
@@ -398,13 +393,13 @@ let cValue1 = params.myTestStruct.prop; // 99
 let cValue2 = params.myTestStruct.another_prop; // 1, 2, 3
 ```
 
-## Sampler - addSampler
+## Sampler - setSampler
 
 A sampler for textures is sometimes required, and you need to explicitly reference it.
 
 Don't name it just `sampler` , because that's the data type inside WGSL. `POINTS` will throw an exception if you do.
 
-A descripttor is assigned by default, if you want to sample your image in a different way, you can take a look at [GPUObjectDescriptorBase](https://gpuweb.github.io/gpuweb/#texture-creation) in the WGSL docs.
+A descriptor is assigned by default, if you want to sample your image in a different way, you can take a look at [GPUTextureDescriptor](https://gpuweb.github.io/gpuweb/#texture-creation) in the WGSL docs.
 
 ```js
 // main.js
@@ -420,7 +415,7 @@ async function init() {
         //maxAnisotropy: 10,
     }
 
-    points.addSampler('mySampler', descriptor);
+    points.setSampler('mySampler', descriptor);
 
     // more init code
     await points.init(renderPasses);
@@ -433,7 +428,7 @@ async function init() {
 let rgba = textureSample(texture, mySampler, uv);
 ```
 
-## Texture - addTexture2d
+## Texture - setTexture2d
 
 You can create an empty texture, which is not very useful on its own, but if you set the second parameter to true, after the Fragment Shader is printed out to screen, it saves the output value to this texture and you can use it in the next update call, so basically you can sample the value from the previous frame.
 
@@ -443,7 +438,7 @@ There's also a third parameter that signals the texture to only capture that Ren
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    points.addTexture2d('feedbackTexture', true, 0);
+    points.setTexture2d('feedbackTexture', true, 0);
 
     // more init code
     await points.init(renderPasses);
@@ -456,16 +451,16 @@ async function init() {
 let rgba = textureSampleLevel(feedbackTexture, feedbackSampler, vec2<f32>(0,0),  0.0);
 ```
 
-## TextureImage - addTextureImage
+## TextureImage - setTextureImage
 
-With `addTextureImage` you can pass an image and sample it with the Sampler you just added.
+With `setTextureImage` you can pass an image and sample it with the Sampler you just added.
 
 ```js
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
     // await since the resource is async we need to wait for it to be ready
-    await points.addTextureImage('image', './../img/absulit_800x800.jpg');
+    await points.setTextureImage('image', './../img/absulit_800x800.jpg');
 
     // more init code
     await points.init(renderPasses);
@@ -479,7 +474,7 @@ let startPosition = vec2(.0);
 let rgbaImage = texturePosition(image, mySampler, startPosition, uv, false);
 ```
 
-## Storage - addStorage
+## Storage - setStorage
 
 A storage is a large array with the same data type and this data can be modified at runtime inside the shaders, so in principle this is different to any other data type here where you can only send data and not modify it in the shaders, or as the uniforms where the data can only be updated from the JavaScript side. You can allocate this space and use it in the shaders and the data will remain in the next update/frame call.
 
@@ -498,8 +493,8 @@ async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
 
     const numPoints = 800 * 800;
-    points.addStorage('value_noise_data', `array<f32, ${numPoints}>`);
-    points.addStorage('variables', 'Variable');
+    points.setStorage('value_noise_data', `array<f32, ${numPoints}>`);
+    points.setStorage('variables', 'Variable');
 
     // more init code
     await points.init(renderPasses);
@@ -511,7 +506,7 @@ async function init() {
 // compute.js outside the main function in the shader
 
 // declare struct referenced here:
-// points.addStorage('variables', 1, 'Variable', 1);
+// points.setStorage('variables', 1, 'Variable', 1);
 struct Variable {
     isCreated:f32
 }
@@ -530,20 +525,20 @@ variables.isCreated = 1;
 You can also add a default type instead of a custom struct in `structName`:
 
 ```js
-points.addStorage('myVar', 'f32');
-points.addStorage('myVar2', 'vec2f');
+points.setStorage('myVar', 'f32');
+points.setStorage('myVar2', 'vec2f');
 ```
 
-## StorageMap - addStorageMap
+## StorageMap - setStorageMap
 
-Creates a Storage in the same way as a `addStorage` does, except it can be set with data from the start of the application.
+Creates a Storage in the same way as a `setStorage` does, except it can be set with data from the start of the application.
 
 ```js
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
 
-    points.addStorageMap('values', [1.0, 99.0], 'array<f32, 2>');
+    points.setStorageMap('values', [1.0, 99.0], 'array<f32, 2>');
 
     // more init code
     await points.init(renderPasses);
@@ -558,9 +553,9 @@ async function init() {
 let c = values[1];
 ```
 
-## BindingTexture - addBindingTexture
+## BindingTexture - setBindingTexture
 
-If you require to send data as a texture from the Compute Shader to the Fragment shader and you do not want to use a Storage, you can use a `addBindingTexture()` , then in the compute shader a variable will exist where you can write colors to it, and in the Fragment Shader will exist a variable to read data from it.
+If you require to send data as a texture from the Compute Shader to the Fragment shader and you do not want to use a Storage, you can use a `setBindingTexture()` , then in the compute shader a variable will exist where you can write colors to it, and in the Fragment Shader will exist a variable to read data from it.
 
 ---
 
@@ -575,7 +570,7 @@ async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
 
     // First parameter goes to Compute Shader, second to Fragment Shader
-    points.addBindingTexture('outputTex', 'computeTexture');
+    points.setBindingTexture('outputTex', 'computeTexture');
 
     // more init code
     await points.init(renderPasses);
@@ -593,7 +588,7 @@ textureStore(outputTex, vec2<u32>(0,0), vec4(1,0,0,1));
 let rgba = textureSample(computeTexture, feedbackSampler, uv);
 ```
 
-## Video - addTextureVideo
+## Video - setTextureVideo
 
 You can load and play a video in the same fashion as a texture. The video is updated with a new value every frame.
 
@@ -601,7 +596,7 @@ You can load and play a video in the same fashion as a texture. The video is upd
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    await points.addTextureVideo('video', './../assets_ignore/VIDEO0244.mp4');
+    await points.setTextureVideo('video', './../assets_ignore/VIDEO0244.mp4');
 
     // more init code
     await points.init(renderPasses);
@@ -614,7 +609,7 @@ async function init() {
 let rgbaVideo = textureSampleBaseClampToEdge(video, feedbackSampler, fract(uv));
 ```
 
-## Webcam - addTextureWebcam
+## Webcam - setTextureWebcam
 
 You can load and play a webcam in the same fashion as a texture. The webcam is updated with a new value every frame.
 
@@ -622,7 +617,7 @@ You can load and play a webcam in the same fashion as a texture. The webcam is u
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    await points.addTextureWebcam('webcam');
+    await points.setTextureWebcam('webcam');
 
     // more init code
     await points.init(renderPasses);
@@ -635,13 +630,13 @@ async function init() {
 let rgbaWebcam = textureSampleBaseClampToEdge(webcam, feedbackSampler, fract(uv));
 ```
 
-## Audio - addAudio
+## Audio - setAudio
 
 You can load audio and use its data for visualization.
 
 ```js
 // index.js
-let audio = points.addAudio('myAudio', './../../audio/cognitive_dissonance.mp3', volume, loop, false);
+let audio = points.setAudio('myAudio', './../../audio/cognitive_dissonance.mp3', volume, loop, false);
 ```
 
 
@@ -653,7 +648,7 @@ let audioX = audio.data[ u32(uvr.x * params.audioLength)] / 256;
 
 ---
 
-> **Note:** The `points.addAudio` method returns a `new Audio` reference, you are responsible to start and stop the audio from the JavaScript side, if you require to start and stop a sound by creating a call from the shaders, please check the `Events - addEventListener` section
+> **Note:** The `points.setAudio` method returns a `new Audio` reference, you are responsible to start and stop the audio from the JavaScript side, if you require to start and stop a sound by creating a call from the shaders, please check the `Events - addEventListener` section
 
 ---
 
@@ -699,7 +694,7 @@ right_blink.updated = 1; // update this property to something diff than `0`
 By just simply changing the value of `updated` to a non zero, the library knows this event has been updated, and will dispatch the event immediately in JavaScript, so the `console.log` will print the text in the JavaScript Console. `updated` will be set as zero in the next frame, and if not updated the library then knows it doesn't have to do anything.
 
 
-## Layers - addLayers
+## Layers - setLayers
 
 A layer is basically a Storage but pre-made with the exact same dimension of the canvas, this for potentially create multi-layered effects that require a type of temporary storage and swap values between them. All items are `vec4<f32>`
 
@@ -709,7 +704,7 @@ To access a layer the first bracket of the array is the layer index and the seco
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    points.addLayers(2);
+    points.setLayers(2);
 
     // more init code
     await points.init(renderPasses);

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ You can call one of the following methods, you pair the data with a `key` name, 
 
 ---
 
-## Uniforms - addUniform
+## Uniforms - setUniform
 
 Uniforms are sent separately in the `main.js` file and they are all combined in the shaders in the struct called `params` . By default, all values are `f32` if no Struct or Type is specified in the third parameter. If values have more than one dimension (`array`, `vec2f`, `vec3f`, `vec4f`...) the data has to be send as an array. Uniforms can not be modified at runtime inside the shaders, they can only receive data from the JavaScript side.
 
@@ -372,9 +372,9 @@ Uniforms are sent separately in the `main.js` file and they are all combined in 
 // main.js
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    points.addUniform('myKeyName', 0); // 0 is your default value
-    points.addUniform('myTestVec2', [0.2, 2.1], 'vec2f'); // array of lenght 2 as data
-    points.addUniform('myTestStruct', [99, 1, 2, 3], 'MyTestStruct'); // prop value is 99 and the rest is a vec3f
+    points.setUniform('myKeyName', 0); // 0 is your default value
+    points.setUniform('myTestVec2', [0.2, 2.1], 'vec2f'); // array of lenght 2 as data
+    points.setUniform('myTestStruct', [99, 1, 2, 3], 'MyTestStruct'); // prop value is 99 and the rest is a vec3f
 
     // more init code
     await points.init(renderPasses);
@@ -758,7 +758,7 @@ let myKeyNameValue = 10;
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
     // myKeyName value 10
-    points.addUniform('myKeyName', myKeyNameValue);
+    points.setUniform('myKeyName', myKeyNameValue);
 
     // more init code
     await points.init(renderPasses);
@@ -768,7 +768,7 @@ async function init() {
 function update() {
     myKeyNameValue += 1;
     // updated myKeyName value increases on each frame
-    points.updateUniform('myKeyName', myKeyNameValue);
+    points.setUniform('myKeyName', myKeyNameValue);
 
     // more update code
     points.update();

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can take a look at `/examples/main.js` and `/examples/index.html`
 ## index.html
 
 ```html
-<canvas id="gl-canvas" width="800" height="800">
+<canvas id="canvas" width="800" height="800">
     Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 ```
@@ -151,7 +151,7 @@ import Points from '../src/absulit.points.module.js';
 import base from '../examples/base/index.js';
 
 // reference the canvas in the constructor
-const points = new Points('gl-canvas');
+const points = new Points('canvas');
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -365,15 +365,30 @@ Uniforms are sent separately in the `main.js` file and they are all combined in 
 
 ```js
 // main.js
+let valueToUpdate = 10;
+
 async function init() {
     let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
     points.setUniform('myKeyName', 0); // 0 is your default value
     points.setUniform('myTestVec2', [0.2, 2.1], 'vec2f'); // array of lenght 2 as data
     points.setUniform('myTestStruct', [99, 1, 2, 3], 'MyTestStruct'); // prop value is 99 and the rest is a vec3f
 
+    // myKeyName value 10
+    points.setUniform('valueToUpdate', myKeyNameValue);
+
     // more init code
     await points.init(renderPasses);
     update();
+}
+
+function update() {
+    valueToUpdate += 1;
+    // updated valueToUpdate value increases on each frame
+    points.setUniform('valueToUpdate', valueToUpdate);
+
+    // more update code
+    points.update();
+    requestAnimationFrame(update);
 }
 ```
 
@@ -391,6 +406,9 @@ let bValue = params.myTestVec2; // 0.2, 2.1
 
 let cValue1 = params.myTestStruct.prop; // 99
 let cValue2 = params.myTestStruct.another_prop; // 1, 2, 3
+
+// value is read the same way, but will vary per frame
+let dValue = params.valueToUpdate;
 ```
 
 ## Sampler - setSampler
@@ -744,38 +762,7 @@ and
 
 ---
 
-## updateUniform
 
-```js
-// main.js
-let myKeyNameValue = 10;
-
-async function init() {
-    let renderPasses = [shaders.vert, shaders.compute, shaders.frag];
-    // myKeyName value 10
-    points.setUniform('myKeyName', myKeyNameValue);
-
-    // more init code
-    await points.init(renderPasses);
-    update();
-}
-
-function update() {
-    myKeyNameValue += 1;
-    // updated myKeyName value increases on each frame
-    points.setUniform('myKeyName', myKeyNameValue);
-
-    // more update code
-    points.update();
-    requestAnimationFrame(update);
-}
-```
-
-```rust
-// frag.js
-// value is read the same way, but will vary per frame
-let aValue = params.myKeyName;
-```
 
 ## updateStorageMap
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" type="text/css" href="style.css">
     </head>
     <body>
-        <canvas id="gl-canvas" width="800" height="800">
+        <canvas id="canvas" width="800" height="800">
             Oops ... your browser doesn't support the HTML5 canvas element
         </canvas>
 

--- a/examples/main.js
+++ b/examples/main.js
@@ -146,7 +146,7 @@ const recordingOptions = [
     {
         nameStopped: 'Download PNG Image',
         fn: function (e) {
-            let image = document.getElementById('gl-canvas').toDataURL().replace('image/png', 'image/octet-stream');
+            let image = document.getElementById('canvas').toDataURL().replace('image/png', 'image/octet-stream');
             window.location.href = image;
         },
     },
@@ -168,10 +168,10 @@ async function init() {
     if (animationFrameId) {
         cancelAnimationFrame(animationFrameId);
     }
-    const canvas = document.getElementById('gl-canvas');
+    const canvas = document.getElementById('canvas');
     canvas.width = 800;
     canvas.height = 800;
-    points = new Points('gl-canvas');
+    points = new Points('canvas');
     isFitWindowData.isFitWindow = false;
 
     gui.removeFolder(optionsFolder);

--- a/src/RenderPass.js
+++ b/src/RenderPass.js
@@ -1,6 +1,23 @@
 'use strict';
 
 export default class RenderPass {
+    #vertexShader;
+    #computeShader;
+    #fragmentShader;
+    #compiledShaders
+    #computePipeline = null;
+    #renderPipeline = null;
+    #computeBindGroup = null;
+    #uniformBindGroup = null;
+    #internal = false;
+    #hasComputeShader;
+    #hasVertexShader;
+    #hasFragmentShader;
+    #hasVertexAndFragmentShader;
+    #workgroupCountX;
+    #workgroupCountY;
+    #workgroupCountZ;
+
     /**
      * A collection of Vertex, Compute and Fragment shaders that represent a RenderPass.
      * This is useful for PostProcessing.
@@ -9,116 +26,108 @@ export default class RenderPass {
      * @param {String} computeShader  WGSL Compute Shader in a String.
      */
     constructor(vertexShader, fragmentShader, computeShader, workgroupCountX, workgroupCountY, workgroupCountZ) {
-        this._vertexShader = vertexShader;
-        this._computeShader = computeShader;
-        this._fragmentShader = fragmentShader;
+        this.#vertexShader = vertexShader;
+        this.#computeShader = computeShader;
+        this.#fragmentShader = fragmentShader;
 
-        this._computePipeline = null;
-        this._renderPipeline = null;
-
-        this._computeBindGroup = null;
-        this._uniformBindGroup = null;
-
-        this._internal = false;
-
-        this._compiledShaders = {
+        this.#compiledShaders = {
             vertex: '',
             compute: '',
             fragment: '',
         };
 
-        this._hasComputeShader = !!this._computeShader;
-        this._hasVertexShader = !!this._vertexShader;
-        this._hasFragmentShader = !!this._fragmentShader;
+        this.#hasComputeShader = !!this.#computeShader;
+        this.#hasVertexShader = !!this.#vertexShader;
+        this.#hasFragmentShader = !!this.#fragmentShader;
 
-        this._hasVertexAndFragmentShader = this._hasVertexShader && this._hasFragmentShader;
+        this.#hasVertexAndFragmentShader = this.#hasVertexShader && this.#hasFragmentShader;
 
-        this._workgroupCountX = workgroupCountX || 8;
-        this._workgroupCountY = workgroupCountY || 8;
-        this._workgroupCountZ = workgroupCountZ || 1;
+        this.#workgroupCountX = workgroupCountX || 8;
+        this.#workgroupCountY = workgroupCountY || 8;
+        this.#workgroupCountZ = workgroupCountZ || 1;
     }
 
     get internal() {
-        return this._internal;
+        return this.#internal;
     }
 
     set internal(value) {
-        this._internal = value;
+        this.#internal = value;
     }
 
     get vertexShader() {
-        return this._vertexShader;
+        return this.#vertexShader;
     }
 
     get computeShader() {
-        return this._computeShader;
+        return this.#computeShader;
     }
 
     get fragmentShader() {
-        return this._fragmentShader;
+        return this.#fragmentShader;
     }
 
     set computePipeline(value) {
-        this._computePipeline = value;
+        this.#computePipeline = value;
     }
 
     get computePipeline() {
-        return this._computePipeline;
+        return this.#computePipeline;
     }
 
     set renderPipeline(value) {
-        this._renderPipeline = value;
+        this.#renderPipeline = value;
     }
 
     get renderPipeline() {
-        return this._renderPipeline;
+        return this.#renderPipeline;
     }
 
     set computeBindGroup(value) {
-        this._computeBindGroup = value;
+        this.#computeBindGroup = value;
     }
 
     get computeBindGroup() {
-        return this._computeBindGroup;
+        return this.#computeBindGroup;
     }
 
     set uniformBindGroup(value) {
-        this._uniformBindGroup = value;
+        this.#uniformBindGroup = value;
     }
 
     get uniformBindGroup() {
-        return this._uniformBindGroup;
+        return this.#uniformBindGroup;
     }
 
     get compiledShaders() {
-        return this._compiledShaders;
+        return this.#compiledShaders;
     }
 
     get hasComputeShader() {
-        return this._hasComputeShader;
+        return this.#hasComputeShader;
     }
 
     get hasVertexShader() {
-        return this._hasVertexShader;
+        return this.#hasVertexShader;
     }
 
     get hasFragmentShader() {
-        return this._hasFragmentShader;
+        return this.#hasFragmentShader;
     }
 
     get hasVertexAndFragmentShader() {
-        return this._hasVertexAndFragmentShader;
+        return this.#hasVertexAndFragmentShader;
     }
 
     get workgroupCountX() {
-        return this._workgroupCountX;
+        return this.#workgroupCountX;
     }
 
     get workgroupCountY() {
-        return this._workgroupCountY;
+        return this.#workgroupCountY;
     }
 
     get workgroupCountZ() {
-        return this._workgroupCountZ;
+        return this.#workgroupCountZ;
     }
 }

--- a/src/RenderPasses.js
+++ b/src/RenderPasses.js
@@ -50,7 +50,7 @@ export default class RenderPasses {
         let shaders = RenderPasses._LIST[renderPassId];
         let renderPass = new RenderPass(shaders.vertexShader, shaders.fragmentShader, shaders.computeShader);
         renderPass.internal = true;
-        points._postRenderPasses.push(renderPass);
+        points.addRenderPass(renderPass);
         await shaders.init(points, params)
     }
 

--- a/src/RenderPasses.js
+++ b/src/RenderPasses.js
@@ -25,7 +25,7 @@ export default class RenderPasses {
     static BLUR = 8;
     static WAVES = 9;
 
-    static _LIST = {
+    static #LIST = {
         1: color,
         2: grayscale,
         3: chromaticAberration,
@@ -44,10 +44,10 @@ export default class RenderPasses {
      * @param {Object} params An object with the params needed by the `RenderPass`
      */
     static async add(points, renderPassId, params) {
-        if (points._renderPasses?.length) {
+        if (points.renderPasses?.length) {
             throw '`addPostRenderPass` should be called prior `Points.init()`';
         }
-        let shaders = RenderPasses._LIST[renderPassId];
+        let shaders = this.#LIST[renderPassId];
         let renderPass = new RenderPass(shaders.vertexShader, shaders.fragmentShader, shaders.computeShader);
         renderPass.internal = true;
         points.addRenderPass(renderPass);

--- a/src/VertexBufferInfo.js
+++ b/src/VertexBufferInfo.js
@@ -1,6 +1,11 @@
 'use strict';
 
 export default class VertexBufferInfo {
+    #vertexSize
+    #vertexOffset;
+    #colorOffset;
+    #uvOffset;
+    #vertexCount;
     /**
      * Along with the vertexArray it calculates some info like offsets required for the pipeline.
      * @param {Float32Array} vertexArray array with vertex, color and uv data
@@ -10,30 +15,30 @@ export default class VertexBufferInfo {
      * @param {Number} uvOffset index where the uv data starts in a row of `triangleDataLength` items
      */
     constructor(vertexArray, triangleDataLength = 10, vertexOffset = 0, colorOffset = 4, uvOffset = 8) {
-        this._vertexSize = vertexArray.BYTES_PER_ELEMENT * triangleDataLength; // Byte size of ONE triangle data (vertex, color, uv). (one row)
-        this._vertexOffset = vertexArray.BYTES_PER_ELEMENT * vertexOffset;
-        this._colorOffset = vertexArray.BYTES_PER_ELEMENT * colorOffset; // Byte offset of triangle vertex color attribute.
-        this._uvOffset = vertexArray.BYTES_PER_ELEMENT * uvOffset;
-        this._vertexCount = vertexArray.byteLength / this._vertexSize;
+        this.#vertexSize = vertexArray.BYTES_PER_ELEMENT * triangleDataLength; // Byte size of ONE triangle data (vertex, color, uv). (one row)
+        this.#vertexOffset = vertexArray.BYTES_PER_ELEMENT * vertexOffset;
+        this.#colorOffset = vertexArray.BYTES_PER_ELEMENT * colorOffset; // Byte offset of triangle vertex color attribute.
+        this.#uvOffset = vertexArray.BYTES_PER_ELEMENT * uvOffset;
+        this.#vertexCount = vertexArray.byteLength / this.#vertexSize;
     }
 
     get vertexSize() {
-        return this._vertexSize;
+        return this.#vertexSize;
     }
 
     get vertexOffset() {
-        return this._vertexOffset;
+        return this.#vertexOffset;
     }
 
     get colorOffset() {
-        return this._colorOffset;
+        return this.#colorOffset;
     }
 
     get uvOffset() {
-        return this._uvOffset;
+        return this.#uvOffset;
     }
 
     get vertexCount() {
-        return this._vertexCount;
+        return this.#vertexCount;
     }
 }

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -215,7 +215,6 @@ export default class Points {
      * @deprecated use setUniform
      */
     addUniform(name, value, structName) {
-        console.warn('addUniform is deprecated, use setUniform');
         if (structName && isArray(structName)) {
             throw `${structName} is an array, which is currently not supported for Uniforms.`;
         }
@@ -236,7 +235,6 @@ export default class Points {
      * @deprecated use setUniform
      */
     updateUniform(name, value) {
-        console.warn('addUniform is deprecated, use setUniform');
         const variable = this._uniforms.find(v => v.name === name);
         if (!variable) {
             throw '`updateUniform()` can\'t be called without first `addUniform()`.';
@@ -294,12 +292,7 @@ export default class Points {
     }
 
     /**
-     * Creates a persistent memory buffer across every frame call.
-     * @param {string} name Name that the Storage will have in the shader
-     * @param {string} structName Name of the struct already existing on the
-     * shader that will be the array<structName> of the Storage
-     * @param {boolean} read if this is going to be used to read data back
-     * @param {ShaderType} shaderType this tells to what shader the storage is bound
+     * @deprecated use setStorage()
      */
     addStorage(name, structName, read, shaderType, arrayData) {
         if (this._nameExists(this._storage, name)) {
@@ -316,14 +309,35 @@ export default class Points {
             internal: this._internal
         });
     }
+
     /**
-     * Creates a persistent memory buffer across every frame call that can be updated.
-     * @param {string} name Name that the Storage will have in the shader.
-     * @param {array} arrayData array with the data that must match the struct.
+     * Creates a persistent memory buffer across every frame call.
+     * @param {string} name Name that the Storage will have in the shader
      * @param {string} structName Name of the struct already existing on the
-     * shader that will be the array<structName> of the Storage.
-     * @param {boolean} read if this is going to be used to read data back.
+     * shader that will be the array<structName> of the Storage
+     * @param {boolean} read if this is going to be used to read data back
      * @param {ShaderType} shaderType this tells to what shader the storage is bound
+     */
+    setStorage(name, structName, read, shaderType, arrayData) {
+        if (this._nameExists(this._storage, name)) {
+            throw `\`setStorage()\` You have already defined \`${name}\``;
+        }
+        const storage = {
+            mapped: !!arrayData,
+            name: name,
+            structName: structName,
+            // structSize: null,
+            shaderType: shaderType,
+            read: read,
+            buffer: null,
+            internal: this._internal
+        }
+        this._storage.push(storage);
+        return storage;
+    }
+
+    /**
+     * @deprecated
      */
     addStorageMap(name, arrayData, structName, read, shaderType) {
         if (this._nameExists(this._storage, name)) {
@@ -341,12 +355,44 @@ export default class Points {
         });
     }
 
+    /**
+     * @deprecated use setStorageMap
+     */
     updateStorageMap(name, arrayData) {
         const variable = this._storage.find(v => v.name === name);
         if (!variable) {
             throw '`updateStorageMap()` can\'t be called without first `addStorageMap()`.';
         }
         variable.array = arrayData;
+    }
+
+    /**
+     * Creates a persistent memory buffer across every frame call that can be updated.
+     * @param {string} name Name that the Storage will have in the shader.
+     * @param {array} arrayData array with the data that must match the struct.
+     * @param {string} structName Name of the struct already existing on the
+     * shader that will be the array<structName> of the Storage.
+     * @param {boolean} read if this is going to be used to read data back.
+     * @param {ShaderType} shaderType this tells to what shader the storage is bound
+     */
+    setStorageMap(name, arrayData, structName, read, shaderType) {
+        const storageToUpdate = this._nameExists(this._storage, name)
+        if (storageToUpdate) {
+            storageToUpdate.array = arrayData;
+            return storageToUpdate;
+        }
+        const storage = {
+            mapped: true,
+            name: name,
+            structName: structName,
+            shaderType: shaderType,
+            array: arrayData,
+            buffer: null,
+            read: read,
+            internal: this._internal
+        }
+        this._storage.push(storage);
+        return storage;
     }
 
     async readStorage(name) {
@@ -460,7 +506,6 @@ export default class Points {
      * @deprecated uset setTextureImage
      */
     async addTextureImage(name, path, shaderType) {
-        console.warn('addTextureImage is deprecated, use setTextureImage');
         if (this._nameExists(this._textures2d, name)) {
             return;
         }
@@ -485,7 +530,6 @@ export default class Points {
      * @deprecated uset setTextureImage
      */
     async updateTextureImage(name, path, shaderType) {
-        console.warn('updateTextureImage is deprecated, use setTextureImage');
         if (!this._nameExists(this._textures2d, name)) {
             console.warn('image can not be updated')
             return;

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -923,9 +923,14 @@ export default class Points {
      * Mainly to be used with RenderPasses.js
      * @param {RenderPass} renderPass
      */
-    addRenderPass(renderPass){
+    addRenderPass(renderPass) {
         this.#postRenderPasses.push(renderPass);
     }
+
+    get renderPasses() {
+        return this.#renderPasses;
+    }
+
     /**
      * Adds two triangles called points per number of columns and rows
      */

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -10,208 +10,137 @@ import { defaultVertexBody } from './core/defaultFunctions.js';
 import { dataSize, getArrayTypeData, isArray, typeSizes } from './data-size.js';
 
 export default class Points {
+    #canvasId = null;
+    #canvas = null;
+    #device = null;
+    #context = null;
+    #presentationFormat = null;
+    #renderPasses = null
+    #postRenderPasses = [];
+    #vertexBufferInfo = null;
+    #buffer = null;
+    #internal = false;
+    #presentationSize = null;
+    #depthTexture = null;
+    #vertexArray = [];
+    #numColumns = 1;
+    #numRows = 1;
+    #commandsFinished = [];
+    #renderPassDescriptor = null;
+    #uniforms = [];
+    #storage = [];
+    #readStorage = [];
+    #samplers = [];
+    #textures2d = [];
+    #texturesToCopy = [];
+    #textures2dArray = [];
+    #texturesExternal = [];
+    #texturesStorage2d = [];
+    #bindingTextures = [];
+    #layers = [];
+    #originalCanvasWidth = null;
+    #originalCanvasHeigth = null;
+    #clock = new Clock();
+    #time = 0;
+    #delta = 0;
+    #epoch = 0;
+    #mouseX = 0;
+    #mouseY = 0;
+    #mouseDown = false;
+    #mouseClick = false;
+    #mouseWheel = false;
+    #mouseDelta = [0, 0];
+    #fullscreen = false;
+    #fitWindow = false;
+    #lastFitWindow = false;
+    #sounds = []; // audio
+    #events = new Map();
+    #events_ids = 0;
+    #dataSize = null;
+
     constructor(canvasId) {
-        // TODO: change @private and _var to #var in all uses even private methods
-        /** @private */
-        this._canvasId = canvasId;
-        /** @private */
-        this._canvas = document.getElementById(this._canvasId);
-        /** @private */
-        this._device = null;
-        /** @private */
-        this._context = null;
-        /** @private */
-        this._presentationFormat = null;
-        /** @private */
-        this._renderPasses = null;
-        /** @private */
-        this._postRenderPasses = [];
-        /** @private */
-        this._vertexBufferInfo = null;
-        /** @private */
-        this._buffer = null;
-        /** @private */
-        this._internal = false;
-
-        /** @private */
-        this._presentationSize = null;
-        /** @private */
-        this._depthTexture = null;
-        /** @private */
-        this._commandEncoder = null;
-
-        /** @private */
-        this._vertexArray = [];
-
-        /** @private */
-        this._numColumns = 1;
-        /** @private */
-        this._numRows = 1;
-
-        /** @private */
-        this._commandsFinished = [];
-
-        /** @private */
-        this._renderPassDescriptor = null;
-
-        /** @private */
-        this._uniforms = [];
-        /** @private */
-        this._storage = [];
-        /** @private */
-        this._readStorage = [];
-        /** @private */
-        this._samplers = [];
-        /** @private */
-        this._textures2d = [];
-        /** @private */
-        this._texturesToCopy = [];
-        /** @private */
-        this._textures2dArray = [];
-        /** @private */
-        this._texturesExternal = [];
-        /** @private */
-        this._texturesStorage2d = [];
-        /** @private */
-        this._bindingTextures = [];
-
-        /** @private */
-        this._layers = [];
-
-        /** @private */
-        this._originalCanvasWidth = null;
-        /** @private */
-        this._originalCanvasHeigth = null;
-
-
-        /** @private */
-        this._clock = new Clock();
-        /** @private */
-        this._time = 0;
-        /** @private */
-        this._epoch = 0;
-        /** @private */
-        this._mouseX = 0;
-        /** @private */
-        this._mouseY = 0;
-        /** @private */
-        this._mouseDown = false;
-        /** @private */
-        this._mouseClick = false;
-        /** @private */
-        this._mouseWheel = false;
-        /** @private */
-        this._mouseDelta = [0, 0];
-
-        /** @private */
-        this._fullscreen = false;
-        /** @private */
-        this._fitWindow = false;
-        /** @private */
-        this._lastFitWindow = false;
-
-        // audio
-        /** @private */
-        this._sounds = [];
-
-        /** @private */
-        this._events = new Map();
-        /** @private */
-        this._events_ids = 0;
-
-        if (this._canvasId) {
-            this._canvas.addEventListener('click', e => {
-                this._mouseClick = true;
+        this.#canvasId = canvasId;
+        this.#canvas = document.getElementById(this.#canvasId);
+        if (this.#canvasId) {
+            this.#canvas.addEventListener('click', e => {
+                this.#mouseClick = true;
             });
-            this._canvas.addEventListener('mousemove', this._onMouseMove, { passive: true });
-            this._canvas.addEventListener('mousedown', e => {
-                this._mouseDown = true;
+            this.#canvas.addEventListener('mousemove', this.#onMouseMove, { passive: true });
+            this.#canvas.addEventListener('mousedown', e => {
+                this.#mouseDown = true;
             });
-            this._canvas.addEventListener('mouseup', e => {
-                this._mouseDown = false;
+            this.#canvas.addEventListener('mouseup', e => {
+                this.#mouseDown = false;
             });
-
-            this._canvas.addEventListener('wheel', e => {
-                this._mouseWheel = true;
-                this._mouseDelta = [e.deltaX, e.deltaY];
+            this.#canvas.addEventListener('wheel', e => {
+                this.#mouseWheel = true;
+                this.#mouseDelta = [e.deltaX, e.deltaY];
             }, { passive: true });
-            this._originalCanvasWidth = this._canvas.clientWidth;
-            this._originalCanvasHeigth = this._canvas.clientHeight;
-            window.addEventListener('resize', this._resizeCanvasToFitWindow, false);
-
+            this.#originalCanvasWidth = this.#canvas.clientWidth;
+            this.#originalCanvasHeigth = this.#canvas.clientHeight;
+            window.addEventListener('resize', this.#resizeCanvasToFitWindow, false);
             document.addEventListener("fullscreenchange", e => {
                 let isFullscreen = !!document.fullscreenElement;
-                this._fullscreen = isFullscreen;
-                if (!isFullscreen && !this._fitWindow) {
-                    this._resizeCanvasToDefault();
+                this.#fullscreen = isFullscreen;
+                if (!isFullscreen && !this.#fitWindow) {
+                    this.#resizeCanvasToDefault();
                 }
                 if (!isFullscreen) {
-                    this.fitWindow = this._lastFitWindow;
+                    this.fitWindow = this.#lastFitWindow;
                 }
             });
         }
-
-
     }
 
-    /** @private */
-    _resizeCanvasToFitWindow = () => {
-        if (this._fitWindow) {
-            this._canvas.width = window.innerWidth;
-            this._canvas.height = window.innerHeight;
-            this._setScreenSize();
+    #resizeCanvasToFitWindow = () => {
+        if (this.#fitWindow) {
+            this.#canvas.width = window.innerWidth;
+            this.#canvas.height = window.innerHeight;
+            this.#setScreenSize();
         }
     }
 
-    /** @private */
-    _resizeCanvasToDefault = () => {
-        this._canvas.width = this._originalCanvasWidth;
-        this._canvas.height = this._originalCanvasHeigth;
-        this._setScreenSize();
+    #resizeCanvasToDefault = () => {
+        this.#canvas.width = this.#originalCanvasWidth;
+        this.#canvas.height = this.#originalCanvasHeigth;
+        this.#setScreenSize();
     }
 
-    /** @private */
-    _setScreenSize = () => {
-        this._presentationSize = [
-            this._canvas.clientWidth,
-            this._canvas.clientHeight,
+    #setScreenSize = () => {
+        this.#presentationSize = [
+            this.#canvas.clientWidth,
+            this.#canvas.clientHeight,
         ];
-
-        this._context.configure({
-            device: this._device,
-            format: this._presentationFormat,
-            //size: this._presentationSize,
-            width: this._canvas.clientWidth,
-            height: this._canvas.clientHeight,
+        this.#context.configure({
+            device: this.#device,
+            format: this.#presentationFormat,
+            //size: this.#presentationSize,
+            width: this.#canvas.clientWidth,
+            height: this.#canvas.clientHeight,
             alphaMode: 'premultiplied',
-
             // Specify we want both RENDER_ATTACHMENT and COPY_SRC since we
             // will copy out of the swapchain texture.
             usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
         });
-
-        this._depthTexture = this._device.createTexture({
-            size: this._presentationSize,
+        this.#depthTexture = this.#device.createTexture({
+            size: this.#presentationSize,
             format: 'depth24plus',
             usage: GPUTextureUsage.RENDER_ATTACHMENT,
         });
-
         // this is to solve an issue that requires the texture to be resized
         // if the screen dimensions change, this for a `addTexture2d` with
         // `copyCurrentTexture` parameter set to `true`.
-        this._textures2d.forEach(texture2d => {
+        this.#textures2d.forEach(texture2d => {
             if (!texture2d.imageTexture && texture2d.texture) {
-                this._createTextureBindingToCopy(texture2d);
+                this.#createTextureBindingToCopy(texture2d);
             }
         })
     }
 
-    /** @private */
-    _onMouseMove = e => {
-        this._mouseX = e.clientX;
-        this._mouseY = e.clientY;
+    #onMouseMove = e => {
+        this.#mouseX = e.clientX;
+        this.#mouseY = e.clientY;
     }
-
     /**
      * @deprecated use setUniform
      */
@@ -219,24 +148,22 @@ export default class Points {
         if (structName && isArray(structName)) {
             throw `${structName} is an array, which is currently not supported for Uniforms.`;
         }
-        if (this._nameExists(this._uniforms, name)) {
+        if (this.#nameExists(this.#uniforms, name)) {
             return;
         }
-
-        this._uniforms.push({
+        this.#uniforms.push({
             name: name,
             value: value,
             type: structName,
             size: null,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * @deprecated use setUniform
      */
     updateUniform(name, value) {
-        const variable = this._uniforms.find(v => v.name === name);
+        const variable = this.#uniforms.find(v => v.name === name);
         if (!variable) {
             throw '`updateUniform()` can\'t be called without first `addUniform()`.';
         }
@@ -252,7 +179,7 @@ export default class Points {
      * @param {string} structName type as `f32` or a custom struct. Default `few`
      */
     setUniform(name, value, structName = null) {
-        let uniformToUpdate = this._nameExists(this._uniforms, name);
+        let uniformToUpdate = this.#nameExists(this.#uniforms, name);
         if (uniformToUpdate && structName) {
             //if name exists is an update
             throw '`setUniform()` can\'t set the structName of an already defined uniform.';
@@ -261,23 +188,19 @@ export default class Points {
             uniformToUpdate.value = value;
             return;
         }
-
         if (structName && isArray(structName)) {
             throw `${structName} is an array, which is currently not supported for Uniforms.`;
         }
-
         const uniform = {
             name: name,
             value: value,
             type: structName,
             size: null,
-            internal: this._internal
+            internal: this.#internal
         }
-
-        this._uniforms.push(uniform);
+        this.#uniforms.push(uniform);
         return uniform;
     }
-
     /**
      * Update a list of uniforms
      * @param {Array<Object>} array object array of the type: `{name, value}`
@@ -285,22 +208,21 @@ export default class Points {
     // TODO: change to setUniforms
     updateUniforms(arr) {
         arr.forEach(uniform => {
-            const variable = this._uniforms.find(v => v.name === uniform.name);
+            const variable = this.#uniforms.find(v => v.name === uniform.name);
             if (!variable) {
                 throw '`updateUniform()` can\'t be called without first `addUniform()`.';
             }
             variable.value = uniform.value;
         })
     }
-
     /**
      * @deprecated use setStorage()
      */
     addStorage(name, structName, read, shaderType, arrayData) {
-        if (this._nameExists(this._storage, name)) {
+        if (this.#nameExists(this.#storage, name)) {
             return;
         }
-        this._storage.push({
+        this.#storage.push({
             mapped: !!arrayData,
             name: name,
             structName: structName,
@@ -308,10 +230,9 @@ export default class Points {
             shaderType: shaderType,
             read: read,
             buffer: null,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * Creates a persistent memory buffer across every frame call.
      * @param {string} name Name that the Storage will have in the shader
@@ -321,7 +242,7 @@ export default class Points {
      * @param {ShaderType} shaderType this tells to what shader the storage is bound
      */
     setStorage(name, structName, read, shaderType, arrayData) {
-        if (this._nameExists(this._storage, name)) {
+        if (this.#nameExists(this.#storage, name)) {
             throw `\`setStorage()\` You have already defined \`${name}\``;
         }
         const storage = {
@@ -332,20 +253,19 @@ export default class Points {
             shaderType: shaderType,
             read: read,
             buffer: null,
-            internal: this._internal
+            internal: this.#internal
         }
-        this._storage.push(storage);
+        this.#storage.push(storage);
         return storage;
     }
-
     /**
      * @deprecated
      */
     addStorageMap(name, arrayData, structName, read, shaderType) {
-        if (this._nameExists(this._storage, name)) {
+        if (this.#nameExists(this.#storage, name)) {
             return;
         }
-        this._storage.push({
+        this.#storage.push({
             mapped: true,
             name: name,
             structName: structName,
@@ -353,21 +273,19 @@ export default class Points {
             array: arrayData,
             buffer: null,
             read: read,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * @deprecated use setStorageMap
      */
     updateStorageMap(name, arrayData) {
-        const variable = this._storage.find(v => v.name === name);
+        const variable = this.#storage.find(v => v.name === name);
         if (!variable) {
             throw '`updateStorageMap()` can\'t be called without first `addStorageMap()`.';
         }
         variable.array = arrayData;
     }
-
     /**
      * Creates a persistent memory buffer across every frame call that can be updated.
      * @param {string} name Name that the Storage will have in the shader.
@@ -378,7 +296,7 @@ export default class Points {
      * @param {ShaderType} shaderType this tells to what shader the storage is bound
      */
     setStorageMap(name, arrayData, structName, read, shaderType) {
-        const storageToUpdate = this._nameExists(this._storage, name)
+        const storageToUpdate = this.#nameExists(this.#storage, name)
         if (storageToUpdate) {
             storageToUpdate.array = arrayData;
             return storageToUpdate;
@@ -391,14 +309,13 @@ export default class Points {
             array: arrayData,
             buffer: null,
             read: read,
-            internal: this._internal
+            internal: this.#internal
         }
-        this._storage.push(storage);
+        this.#storage.push(storage);
         return storage;
     }
-
     async readStorage(name) {
-        let storageItem = this._readStorage.find(storageItem => storageItem.name === name);
+        let storageItem = this.#readStorage.find(storageItem => storageItem.name === name);
         let arrayBuffer = null;
         let arrayBufferCopy = null;
         if (storageItem) {
@@ -409,28 +326,25 @@ export default class Points {
         }
         return arrayBufferCopy;
     }
-
     // TODO: change to setLayers
     addLayers(numLayers, shaderType) {
         for (let layerIndex = 0; layerIndex < numLayers; layerIndex++) {
-            this._layers.shaderType = shaderType;
-            this._layers.push({
+            this.#layers.shaderType = shaderType;
+            this.#layers.push({
                 name: `layer${layerIndex}`,
-                size: this._canvas.width * this._canvas.height,
+                size: this.#canvas.width * this.#canvas.height,
                 structName: 'vec4<f32>',
                 structSize: 16,
                 array: null,
                 buffer: null,
-                internal: this._internal
+                internal: this.#internal
             });
         }
     }
 
-    /** @private */
-    _nameExists(arrayOfObjects, name) {
+    #nameExists(arrayOfObjects, name) {
         return arrayOfObjects.find(obj => obj.name == name);
     }
-
     /**
      * Creates a `sampler` to be sent to the shaders.
      * @param {string} name Name of the `sampler` to be called in the shaders.
@@ -441,11 +355,9 @@ export default class Points {
         if ('sampler' == name) {
             throw '`name` can not be sampler since is a WebGPU keyword';
         }
-
-        if (this._nameExists(this._samplers, name)) {
+        if (this.#nameExists(this.#samplers, name)) {
             return;
         }
-
         // Create a sampler with linear filtering for smooth interpolation.
         descriptor = descriptor || {
             addressModeU: 'clamp-to-edge',
@@ -455,16 +367,14 @@ export default class Points {
             mipmapFilter: 'linear',
             //maxAnisotropy: 10,
         };
-
-        this._samplers.push({
+        this.#samplers.push({
             name: name,
             descriptor: descriptor,
             shaderType: shaderType,
             resource: null,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * Create a `texture_2d` in the shaders.
      * @param {string} name Name to call the texture in the shaders.
@@ -472,29 +382,26 @@ export default class Points {
      */
     // TODO: change to setTexture2d
     addTexture2d(name, copyCurrentTexture, shaderType, renderPassIndex) {
-        if (this._nameExists(this._textures2d, name)) {
+        if (this.#nameExists(this.#textures2d, name)) {
             return;
         }
-        this._textures2d.push({
+        this.#textures2d.push({
             name: name,
             copyCurrentTexture: copyCurrentTexture,
             shaderType: shaderType,
             texture: null,
             renderPassIndex: renderPassIndex,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     copyTexture(nameTextureA, nameTextureB) {
-        const texture2d_A = this._nameExists(this._textures2d, nameTextureA);
-        const texture2d_B = this._nameExists(this._textures2d, nameTextureB);
-
+        const texture2d_A = this.#nameExists(this.#textures2d, nameTextureA);
+        const texture2d_B = this.#nameExists(this.#textures2d, nameTextureB);
         if (!(texture2d_A && texture2d_B)) {
             console.error('One of the textures does not exist.');
         }
         const a = texture2d_A.texture;
-
-        const cubeTexture = this._device.createTexture({
+        const cubeTexture = this.#device.createTexture({
             size: [a.width, a.height, 1],
             format: 'rgba8unorm',
             usage:
@@ -503,23 +410,19 @@ export default class Points {
                 GPUTextureUsage.RENDER_ATTACHMENT,
         });
         texture2d_B.texture = cubeTexture;
-
-        this._texturesToCopy.push({ a, b: texture2d_B.texture });
+        this.#texturesToCopy.push({ a, b: texture2d_B.texture });
     }
-
     /**
      * @deprecated use setTextureImage
      */
     async addTextureImage(name, path, shaderType) {
-        if (this._nameExists(this._textures2d, name)) {
+        if (this.#nameExists(this.#textures2d, name)) {
             return;
         }
-
         const response = await fetch(path);
         const blob = await response.blob();
         const imageBitmap = await createImageBitmap(blob);
-
-        this._textures2d.push({
+        this.#textures2d.push({
             name: name,
             copyCurrentTexture: false,
             shaderType: shaderType,
@@ -527,27 +430,23 @@ export default class Points {
             imageTexture: {
                 bitmap: imageBitmap
             },
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * @deprecated uset setTextureImage
      */
     async updateTextureImage(name, path, shaderType) {
-        if (!this._nameExists(this._textures2d, name)) {
+        if (!this.#nameExists(this.#textures2d, name)) {
             console.warn('image can not be updated')
             return;
         }
-
         const response = await fetch(path);
         const blob = await response.blob();
         const imageBitmap = await createImageBitmap(blob);
-
-        const texture2d = this._textures2d.filter(obj => obj.name == name)[0];
+        const texture2d = this.#textures2d.filter(obj => obj.name == name)[0];
         texture2d.imageTexture.bitmap = imageBitmap;
-
-        const cubeTexture = this._device.createTexture({
+        const cubeTexture = this.#device.createTexture({
             size: [imageBitmap.width, imageBitmap.height, 1],
             format: 'rgba8unorm',
             usage:
@@ -556,15 +455,13 @@ export default class Points {
                 GPUTextureUsage.COPY_DST |
                 GPUTextureUsage.RENDER_ATTACHMENT,
         });
-
-        this._device.queue.copyExternalImageToTexture(
+        this.#device.queue.copyExternalImageToTexture(
             { source: imageBitmap },
             { texture: cubeTexture },
             [imageBitmap.width, imageBitmap.height]
         );
         texture2d.texture = cubeTexture;
     }
-
     /**
      * Load an image as texture_2d
      * @param {string} name
@@ -572,19 +469,16 @@ export default class Points {
      * @param {ShaderType} shaderType
      */
     async setTextureImage(name, path, shaderType = null) {
-        const texture2dToUpdate = this._nameExists(this._textures2d, name);
-
+        const texture2dToUpdate = this.#nameExists(this.#textures2d, name);
         const response = await fetch(path);
         const blob = await response.blob();
         const imageBitmap = await createImageBitmap(blob);
-
         if (texture2dToUpdate) {
             if (shaderType) {
                 throw '`setTextureImage()` the param `shaderType` should not be updated after its creation.';
             }
             texture2dToUpdate.imageTexture.bitmap = imageBitmap;
-
-            const cubeTexture = this._device.createTexture({
+            const cubeTexture = this.#device.createTexture({
                 size: [imageBitmap.width, imageBitmap.height, 1],
                 format: 'rgba8unorm',
                 usage:
@@ -593,8 +487,7 @@ export default class Points {
                     GPUTextureUsage.COPY_DST |
                     GPUTextureUsage.RENDER_ATTACHMENT,
             });
-
-            this._device.queue.copyExternalImageToTexture(
+            this.#device.queue.copyExternalImageToTexture(
                 { source: imageBitmap },
                 { texture: cubeTexture },
                 [imageBitmap.width, imageBitmap.height]
@@ -602,7 +495,6 @@ export default class Points {
             texture2dToUpdate.texture = cubeTexture;
             return texture2dToUpdate;
         }
-
         const texture2d = {
             name: name,
             copyCurrentTexture: false,
@@ -611,12 +503,11 @@ export default class Points {
             imageTexture: {
                 bitmap: imageBitmap
             },
-            internal: this._internal
+            internal: this.#internal
         }
-        this._textures2d.push(texture2d);
+        this.#textures2d.push(texture2d);
         return texture2d;
     }
-
     /**
      * Load images as texture_2d_array
      * @param {string} name
@@ -624,10 +515,9 @@ export default class Points {
      * @param {ShaderType} shaderType
      */
     async setTextureImageArray(name, paths, shaderType) {
-        if (this._nameExists(this._textures2dArray, name)) {
+        if (this.#nameExists(this.#textures2dArray, name)) {
             return;
         }
-
         const imageBitmaps = [];
         for await (const path of paths) {
             console.log(path);
@@ -635,8 +525,7 @@ export default class Points {
             const blob = await response.blob();
             imageBitmaps.push(await createImageBitmap(blob));
         }
-
-        this._textures2dArray.push({
+        this.#textures2dArray.push({
             name: name,
             copyCurrentTexture: false,
             shaderType: shaderType,
@@ -644,10 +533,9 @@ export default class Points {
             imageTextures: {
                 bitmaps: imageBitmaps
             },
-            internal: this._internal,
+            internal: this.#internal,
         });
     }
-
     /**
      * Load an video as texture2d
      * @param {string} name
@@ -656,7 +544,7 @@ export default class Points {
      */
     // TODO: change to setTextureVideo
     async addTextureVideo(name, path, shaderType) {
-        if (this._nameExists(this._texturesExternal, name)) {
+        if (this.#nameExists(this.#texturesExternal, name)) {
             return;
         }
         const video = document.createElement('video');
@@ -665,18 +553,16 @@ export default class Points {
         video.muted = true;
         video.src = new URL(path, import.meta.url).toString();
         await video.play();
-
-        this._texturesExternal.push({
+        this.#texturesExternal.push({
             name: name,
             shaderType: shaderType,
             video: video,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     // TODO: change to setTextureWebcam
     async addTextureWebcam(name, shaderType) {
-        if (this._nameExists(this._texturesExternal, name)) {
+        if (this.#nameExists(this.#texturesExternal, name)) {
             return;
         }
         const video = document.createElement('video');
@@ -684,7 +570,6 @@ export default class Points {
         //video.autoplay = true;
         video.muted = true;
         //document.body.appendChild(video);
-
         if (navigator.mediaDevices.getUserMedia) {
             await navigator.mediaDevices.getUserMedia({ video: true })
                 .then(async function (stream) {
@@ -695,22 +580,19 @@ export default class Points {
                     console.log(err);
                 });
         }
-
-        this._texturesExternal.push({
+        this.#texturesExternal.push({
             name: name,
             shaderType: shaderType,
             video: video,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     // TODO: change to setAudio
     addAudio(name, path, volume, loop, autoplay) {
         const audio = new Audio(path);
         audio.volume = volume;
         audio.autoplay = autoplay;
         audio.loop = loop;
-
         const sound = {
             name: name,
             path: path,
@@ -718,9 +600,7 @@ export default class Points {
             analyser: null,
             data: null
         }
-
-        // this._audio.play();
-
+        // this.#audio.play();
         // audio
         const audioContext = new AudioContext();
         let resume = _ => { audioContext.resume() }
@@ -728,22 +608,17 @@ export default class Points {
             document.body.addEventListener('touchend', resume, false);
             document.body.addEventListener('click', resume, false);
         }
-
         const source = audioContext.createMediaElementSource(audio);
-
         // // audioContext.createMediaStreamSource()
         const analyser = audioContext.createAnalyser();
         analyser.fftSize = 2048;
-
         source.connect(analyser);
         analyser.connect(audioContext.destination);
-
         const bufferLength = analyser.fftSize;//analyser.frequencyBinCount;
         // const bufferLength = analyser.frequencyBinCount;
         const data = new Uint8Array(bufferLength);
         // analyser.getByteTimeDomainData(data);
         analyser.getByteFrequencyData(data);
-
         // storage that will have the data on WGSL
         this.setStorageMap(name, data,
             // `array<f32, ${bufferLength}>`
@@ -751,28 +626,24 @@ export default class Points {
         );
         // uniform that will have the data length as a quick reference
         this.setUniform(`${name}Length`, analyser.frequencyBinCount);
-
         sound.analyser = analyser;
         sound.data = data;
-        this._sounds.push(sound);
-
+        this.#sounds.push(sound);
         return audio;
     }
-
     // TODO: verify this method
     // TODO: change to setTextureStorage2d
     addTextureStorage2d(name, shaderType) {
-        if (this._nameExists(this._texturesStorage2d, name)) {
+        if (this.#nameExists(this.#texturesStorage2d, name)) {
             return;
         }
-        this._texturesStorage2d.push({
+        this.#texturesStorage2d.push({
             name: name,
             shaderType: shaderType,
             texture: null,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * Adds a texture to the compute and fragment shader, in the compute you can
      * write to the texture, and in the fragment you can read the texture, so is
@@ -784,7 +655,7 @@ export default class Points {
      */
     // TODO: change to setBindingTexture
     addBindingTexture(computeName, fragmentName, size) {
-        this._bindingTextures.push({
+        this.#bindingTextures.push({
             compute: {
                 name: computeName,
                 shaderType: ShaderType.COMPUTE
@@ -795,10 +666,9 @@ export default class Points {
             },
             texture: null,
             size: size,
-            internal: this._internal
+            internal: this.#internal
         });
     }
-
     /**
      * Listen for an event dispatched from WGSL code
      * @param {Number} id Number that represents an event Id
@@ -809,33 +679,30 @@ export default class Points {
         // this extra 4 is for the boolean flag in the Event struct
         let data = Array(structSize + 4).fill(0);
         this.setStorageMap(name, data, 'Event', true);
-        this._events.set(this._events_ids,
+        this.#events.set(this.#events_ids,
             {
-                id: this._events_ids,
+                id: this.#events_ids,
                 name: name,
                 callback: callback,
             }
         );
-
-        ++this._events_ids;
+        ++this.#events_ids;
     }
-
     /**
      * @private
      * for internal use:
      * to flag add* methods and variables as part of the RenderPasses
      */
     _setInternal(value) {
-        this._internal = value;
+        this.#internal = value;
     }
-
     /**
      * @private
      * @param {ShaderType} shaderType
      * @param {boolean} internal
      * @returns string with bindings
      */
-    _createDynamicGroupBindings(shaderType, internal) {
+    #createDynamicGroupBindings(shaderType, internal) {
         // `internal` here is a flag for a custom pass
         internal = internal || false;
         if (!shaderType) {
@@ -844,12 +711,11 @@ export default class Points {
         const groupId = 0;
         let dynamicGroupBindings = '';
         let bindingIndex = 0;
-        if (this._uniforms.length) {
+        if (this.#uniforms.length) {
             dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var <uniform> params: Params;\n`;
             bindingIndex += 1;
         }
-
-        this._storage.forEach(storageItem => {
+        this.#storage.forEach(storageItem => {
             let internalCheck = internal == storageItem.internal;
             if (!storageItem.shaderType && internalCheck || storageItem.shaderType == shaderType && internalCheck) {
                 let T = storageItem.structName;
@@ -857,72 +723,62 @@ export default class Points {
                 bindingIndex += 1;
             }
         });
-
-        if (this._layers.length) {
-            if (!this._layers.shaderType || this._layers.shaderType == shaderType) {
+        if (this.#layers.length) {
+            if (!this.#layers.shaderType || this.#layers.shaderType == shaderType) {
                 let totalSize = 0;
-                this._layers.forEach(layerItem => totalSize += layerItem.size);
+                this.#layers.forEach(layerItem => totalSize += layerItem.size);
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var <storage, read_write> layers: array<array<vec4<f32>, ${totalSize}>>;\n`
                 bindingIndex += 1;
             }
         }
-
-        this._samplers.forEach((sampler, index) => {
+        this.#samplers.forEach((sampler, index) => {
             let internalCheck = internal == sampler.internal;
             if (!sampler.shaderType && internalCheck || sampler.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${sampler.name}: sampler;\n`;
                 bindingIndex += 1;
             }
         });
-
-        this._texturesStorage2d.forEach((texture, index) => {
+        this.#texturesStorage2d.forEach((texture, index) => {
             let internalCheck = internal && texture.internal;
             if (!texture.shaderType && internalCheck || texture.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${texture.name}: texture_storage_2d<rgba8unorm, write>;\n`;
                 bindingIndex += 1;
             }
         });
-
-        this._textures2d.forEach((texture, index) => {
+        this.#textures2d.forEach((texture, index) => {
             let internalCheck = internal == texture.internal;
             if (!texture.shaderType && internalCheck || texture.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${texture.name}: texture_2d<f32>;\n`;
                 bindingIndex += 1;
             }
         });
-
-        this._textures2dArray.forEach((texture, index) => {
+        this.#textures2dArray.forEach((texture, index) => {
             let internalCheck = internal == texture.internal;
             if (!texture.shaderType && internalCheck || texture.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${texture.name}: texture_2d_array<f32>;\n`;
                 bindingIndex += 1;
             }
         });
-
-        this._texturesExternal.forEach(externalTexture => {
+        this.#texturesExternal.forEach(externalTexture => {
             let internalCheck = internal == externalTexture.internal;
             if (!externalTexture.shaderType && internalCheck || externalTexture.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${externalTexture.name}: texture_external;\n`;
                 bindingIndex += 1;
             }
         });
-
-        this._bindingTextures.forEach(bindingTexture => {
+        this.#bindingTextures.forEach(bindingTexture => {
             let internalCheck = internal == bindingTexture.internal;
             if (bindingTexture.compute.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${bindingTexture.compute.name}: texture_storage_2d<rgba8unorm, write>;\n`;
                 bindingIndex += 1;
             }
-
             if (bindingTexture.fragment.shaderType == shaderType && internalCheck) {
                 dynamicGroupBindings += /*wgsl*/`@group(${groupId}) @binding(${bindingIndex}) var ${bindingTexture.fragment.name}: texture_2d<f32>;\n`;
                 bindingIndex += 1;
             }
         });
-
         return dynamicGroupBindings;
     }
-
     /**
      * Establishes the density of the base mesh, by default 1x1, meaning two triangles.
      * The final number of triangles is `numColumns` * `numRows` * `2` ( 2 being the triangles )
@@ -933,46 +789,37 @@ export default class Points {
         if (numColumns == 0 || numRows == 0) {
             throw 'Parameters should be greater than 0';
         }
-        this._numColumns = numColumns;
-        this._numRows = numRows;
+        this.#numColumns = numColumns;
+        this.#numRows = numRows;
     }
 
-    /** @private */
-    _compileRenderPass = (renderPass, index) => {
+    #compileRenderPass = (renderPass, index) => {
         let vertexShader = renderPass.vertexShader;
         let computeShader = renderPass.computeShader;
         let fragmentShader = renderPass.fragmentShader;
-
         let colorsVertWGSL = vertexShader;
         let colorsComputeWGSL = computeShader;
         let colorsFragWGSL = fragmentShader;
-
         let dynamicGroupBindingsVertex = '';
         let dynamicGroupBindingsCompute = '';
         let dynamicGroupBindingsFragment = '';
-
         let dynamicStructParams = '';
-        this._uniforms.forEach(u => {
+        this.#uniforms.forEach(u => {
             u.type = u.type || 'f32';
             dynamicStructParams += /*wgsl*/`${u.name}:${u.type}, \n\t`;
         });
-
-        if (this._uniforms.length) {
+        if (this.#uniforms.length) {
             dynamicStructParams = /*wgsl*/`struct Params {\n\t${dynamicStructParams}\n}\n`;
         }
-
         renderPass.hasVertexShader && (dynamicGroupBindingsVertex += dynamicStructParams);
         renderPass.hasComputeShader && (dynamicGroupBindingsCompute += dynamicStructParams);
         renderPass.hasFragmentShader && (dynamicGroupBindingsFragment += dynamicStructParams);
-
-        renderPass.hasVertexShader && (dynamicGroupBindingsVertex += this._createDynamicGroupBindings(ShaderType.VERTEX, renderPass.internal));
-        renderPass.hasComputeShader && (dynamicGroupBindingsCompute += this._createDynamicGroupBindings(ShaderType.COMPUTE, renderPass.internal));
-        dynamicGroupBindingsFragment += this._createDynamicGroupBindings(ShaderType.FRAGMENT, renderPass.internal);
-
+        renderPass.hasVertexShader && (dynamicGroupBindingsVertex += this.#createDynamicGroupBindings(ShaderType.VERTEX, renderPass.internal));
+        renderPass.hasComputeShader && (dynamicGroupBindingsCompute += this.#createDynamicGroupBindings(ShaderType.COMPUTE, renderPass.internal));
+        dynamicGroupBindingsFragment += this.#createDynamicGroupBindings(ShaderType.FRAGMENT, renderPass.internal);
         renderPass.hasVertexShader && (colorsVertWGSL = dynamicGroupBindingsVertex + defaultStructs + defaultVertexBody + colorsVertWGSL);
         renderPass.hasComputeShader && (colorsComputeWGSL = dynamicGroupBindingsCompute + defaultStructs + colorsComputeWGSL);
         renderPass.hasFragmentShader && (colorsFragWGSL = dynamicGroupBindingsFragment + defaultStructs + colorsFragWGSL);
-
         console.groupCollapsed(`Render Pass ${index}`);
         console.groupCollapsed('VERTEX');
         console.log(colorsVertWGSL);
@@ -986,29 +833,25 @@ export default class Points {
         console.log(colorsFragWGSL);
         console.groupEnd();
         console.groupEnd();
-
         renderPass.hasVertexShader && (renderPass.compiledShaders.vertex = colorsVertWGSL);
         renderPass.hasComputeShader && (renderPass.compiledShaders.compute = colorsComputeWGSL);
         renderPass.hasFragmentShader && (renderPass.compiledShaders.fragment = colorsFragWGSL);
     }
-
-    _generateDataSize = () => {
-        const allShaders = this._renderPasses.map(renderPass => {
+    #generateDataSize = () => {
+        const allShaders = this.#renderPasses.map(renderPass => {
             const { vertex, compute, fragment } = renderPass.compiledShaders;
             return vertex + compute + fragment;;
         }).join('\n');
-
-        this._dataSize = dataSize(allShaders);
-
+        this.#dataSize = dataSize(allShaders);
         // since uniforms are in a sigle struct
         // this is only required for storage
-        this._storage.forEach(s => {
+        this.#storage.forEach(s => {
             if (!s.mapped) {
                 if (isArray(s.structName)) {
-                    const typeData = getArrayTypeData(s.structName, this._dataSize);
+                    const typeData = getArrayTypeData(s.structName, this.#dataSize);
                     s.structSize = typeData.size;
                 } else {
-                    const d = this._dataSize.get(s.structName) || typeSizes[s.structName];
+                    const d = this.#dataSize.get(s.structName) || typeSizes[s.structName];
                     if (!d) {
                         throw `${s.structName} has not been defined.`
                     }
@@ -1017,57 +860,47 @@ export default class Points {
             }
         });
     }
-
     /**
      * One time function to call to initialize the shaders.
      * @param {Array<RenderPass>} renderPasses Collection of RenderPass, which contain Vertex, Compute and Fragment shaders.
      * @returns false | undefined
      */
     async init(renderPasses) {
-
-        this._renderPasses = renderPasses.concat(this._postRenderPasses);
-
+        this.#renderPasses = renderPasses.concat(this.#postRenderPasses);
         // initializing internal uniforms
-        this.setUniform(UniformKeys.TIME, this._time);
-        this.setUniform(UniformKeys.DELTA, this._delta);
-        this.setUniform(UniformKeys.EPOCH, this._epoch);
+        this.setUniform(UniformKeys.TIME, this.#time);
+        this.setUniform(UniformKeys.DELTA, this.#delta);
+        this.setUniform(UniformKeys.EPOCH, this.#epoch);
         this.setUniform(UniformKeys.SCREEN, [0, 0], 'vec2f');
         this.setUniform(UniformKeys.MOUSE, [0, 0], 'vec2f');
-        this.setUniform(UniformKeys.MOUSE_CLICK, this._mouseClick);
-        this.setUniform(UniformKeys.MOUSE_DOWN, this._mouseDown);
-        this.setUniform(UniformKeys.MOUSE_WHEEL, this._mouseWheel);
-        this.setUniform(UniformKeys.MOUSE_DELTA, this._mouseDelta, 'vec2f');
-
-        let hasComputeShaders = this._renderPasses.some(renderPass => renderPass.hasComputeShader);
-        if (!hasComputeShaders && this._bindingTextures.length) {
+        this.setUniform(UniformKeys.MOUSE_CLICK, this.#mouseClick);
+        this.setUniform(UniformKeys.MOUSE_DOWN, this.#mouseDown);
+        this.setUniform(UniformKeys.MOUSE_WHEEL, this.#mouseWheel);
+        this.setUniform(UniformKeys.MOUSE_DELTA, this.#mouseDelta, 'vec2f');
+        let hasComputeShaders = this.#renderPasses.some(renderPass => renderPass.hasComputeShader);
+        if (!hasComputeShaders && this.#bindingTextures.length) {
             throw ' `addBindingTexture` requires at least one Compute Shader in a `RenderPass`'
         }
-
-        this._renderPasses.forEach(this._compileRenderPass);
-        this._generateDataSize();
+        this.#renderPasses.forEach(this.#compileRenderPass);
+        this.#generateDataSize();
         //
-
 
         const adapter = await navigator.gpu.requestAdapter();
         if (!adapter) { return false; }
-        this._device = await adapter.requestDevice();
-        this._device.lost.then(info => {
+        this.#device = await adapter.requestDevice();
+        this.#device.lost.then(info => {
             console.log(info);
         });
-
-        if (this._canvas !== null) this._context = this._canvas.getContext('webgpu');
-
-        this._presentationFormat = navigator.gpu.getPreferredCanvasFormat();
-
-        if (this._canvasId) {
-            if (this._fitWindow) {
-                this._resizeCanvasToFitWindow();
+        if (this.#canvas !== null) this.#context = this.#canvas.getContext('webgpu');
+        this.#presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+        if (this.#canvasId) {
+            if (this.#fitWindow) {
+                this.#resizeCanvasToFitWindow();
             } else {
-                this._resizeCanvasToDefault();
+                this.#resizeCanvasToDefault();
             }
         }
-
-        this._renderPassDescriptor = {
+        this.#renderPassDescriptor = {
             colorAttachments: [
                 {
                     //view: textureView,
@@ -1077,22 +910,27 @@ export default class Points {
                 }
             ],
             depthStencilAttachment: {
-                //view: this._depthTexture.createView(),
+                //view: this.#depthTexture.createView(),
                 depthClearValue: 1.0,
                 depthLoadOp: 'clear',
                 depthStoreOp: 'store'
             }
         };
-
         await this.createScreen();
     }
 
     /**
+     * Mainly to be used with RenderPasses.js
+     * @param {RenderPass} renderPass
+     */
+    addRenderPass(renderPass){
+        this.#postRenderPasses.push(renderPass);
+    }
+    /**
      * Adds two triangles called points per number of columns and rows
      */
     async createScreen() {
-        let hasVertexAndFragmentShader = this._renderPasses.some(renderPass => renderPass.hasVertexAndFragmentShader)
-
+        let hasVertexAndFragmentShader = this.#renderPasses.some(renderPass => renderPass.hasVertexAndFragmentShader)
         if (hasVertexAndFragmentShader) {
             let colors = [
                 new RGBAColor(1, 0, 0),
@@ -1100,31 +938,26 @@ export default class Points {
                 new RGBAColor(0, 0, 1),
                 new RGBAColor(1, 1, 0),
             ];
-
-            for (let xIndex = 0; xIndex < this._numRows; xIndex++) {
-                for (let yIndex = 0; yIndex < this._numColumns; yIndex++) {
-                    const coordinate = new Coordinate(xIndex * this._canvas.clientWidth / this._numColumns, yIndex * this._canvas.clientHeight / this._numRows, .3);
-                    this.addPoint(coordinate, this._canvas.clientWidth / this._numColumns, this._canvas.clientHeight / this._numRows, colors);
+            for (let xIndex = 0; xIndex < this.#numRows; xIndex++) {
+                for (let yIndex = 0; yIndex < this.#numColumns; yIndex++) {
+                    const coordinate = new Coordinate(xIndex * this.#canvas.clientWidth / this.#numColumns, yIndex * this.#canvas.clientHeight / this.#numRows, .3);
+                    this.addPoint(coordinate, this.#canvas.clientWidth / this.#numColumns, this.#canvas.clientHeight / this.#numRows, colors);
                 }
             }
-            this._createVertexBuffer(new Float32Array(this._vertexArray));
+            this.#createVertexBuffer(new Float32Array(this.#vertexArray));
         }
-
-        this._createComputeBuffers();
-
-        await this._createPipeline();
+        this.#createComputeBuffers();
+        await this.#createPipeline();
     }
-
     /**
      * @private
      * @param {Float32Array} vertexArray
      * @returns buffer
      */
-    _createVertexBuffer(vertexArray) {
-        this._vertexBufferInfo = new VertexBufferInfo(vertexArray);
-        this._buffer = this._createAndMapBuffer(vertexArray, GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST);
+    #createVertexBuffer(vertexArray) {
+        this.#vertexBufferInfo = new VertexBufferInfo(vertexArray);
+        this.#buffer = this.#createAndMapBuffer(vertexArray, GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST);
     }
-
     /**
      * @private
      * @param {Float32Array} data
@@ -1132,8 +965,8 @@ export default class Points {
      * @param {Boolean} mappedAtCreation
      * @returns mapped buffer
      */
-    _createAndMapBuffer(data, usage, mappedAtCreation = true, size) {
-        const buffer = this._device.createBuffer({
+    #createAndMapBuffer(data, usage, mappedAtCreation = true, size) {
+        const buffer = this.#device.createBuffer({
             mappedAtCreation: mappedAtCreation,
             size: size || data.byteLength,
             usage: usage,
@@ -1143,7 +976,6 @@ export default class Points {
         return buffer;
     }
 
-
     /**
      * @private
      * It creates with size, no with data, so it's empty
@@ -1151,21 +983,19 @@ export default class Points {
      * @param {GPUBufferUsageFlags} usage
      * @returns buffer
      */
-    _createBuffer(size, usage) {
-        const buffer = this._device.createBuffer({
+    #createBuffer(size, usage) {
+        const buffer = this.#device.createBuffer({
             size: size,
             usage: usage,
         });
         return buffer
     }
 
-    /** @private */
-    _createParametersUniforms() {
-        const paramsDataSize = this._dataSize.get('Params')
+    #createParametersUniforms() {
+        const paramsDataSize = this.#dataSize.get('Params')
         const paddings = paramsDataSize.paddings;
-
         // we check the paddings list and add 0's to just the ones that need it
-        const uniformsClone = JSON.parse(JSON.stringify(this._uniforms));
+        const uniformsClone = JSON.parse(JSON.stringify(this.#uniforms));
         let arrayValues = uniformsClone.map(v => {
             const padding = paddings[v.name];
             if (padding) {
@@ -1178,26 +1008,22 @@ export default class Points {
             }
             return v.value;
         }).flat(1);
-
         const finalPadding = paddings[''];
         if (finalPadding) {
             for (let i = 0; i < finalPadding; i++) {
                 arrayValues.push(0);
             }
         }
-
         const values = new Float32Array(arrayValues);
-        this._uniforms.buffer = this._createAndMapBuffer(values, GPUBufferUsage.UNIFORM, true, paramsDataSize.bytes);
+        this.#uniforms.buffer = this.#createAndMapBuffer(values, GPUBufferUsage.UNIFORM, true, paramsDataSize.bytes);
     }
 
-    /** @private */
-    _createComputeBuffers() {
+    #createComputeBuffers() {
         //--------------------------------------------
-        this._createParametersUniforms();
+        this.#createParametersUniforms();
         //--------------------------------------------
-        this._storage.forEach(storageItem => {
+        this.#storage.forEach(storageItem => {
             let usage = GPUBufferUsage.STORAGE;
-
             if (storageItem.read) {
                 let readStorageItem = {
                     name: storageItem.name,
@@ -1209,52 +1035,49 @@ export default class Points {
                         size: storageItem.array.length,
                     }
                 }
-
-                this._readStorage.push(readStorageItem);
+                this.#readStorage.push(readStorageItem);
                 usage = GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
             }
             storageItem.usage = usage;
             if (storageItem.mapped) {
                 const values = new Float32Array(storageItem.array);
-                storageItem.buffer = this._createAndMapBuffer(values, usage);
+                storageItem.buffer = this.#createAndMapBuffer(values, usage);
             } else {
-                storageItem.buffer = this._createBuffer(storageItem.structSize, usage);
+                storageItem.buffer = this.#createBuffer(storageItem.structSize, usage);
             }
         });
         //--------------------------------------------
-        this._readStorage.forEach(readStorageItem => {
-            readStorageItem.buffer = this._device.createBuffer({
+        this.#readStorage.forEach(readStorageItem => {
+            readStorageItem.buffer = this.#device.createBuffer({
                 size: readStorageItem.size,
                 usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
             });
         });
         //--------------------------------------------
-        if (this._layers.length) {
+        if (this.#layers.length) {
             //let layerValues = [];
             let layersSize = 0;
-            this._layers.forEach(layerItem => {
+            this.#layers.forEach(layerItem => {
                 layersSize += layerItem.size * layerItem.structSize;
             });
-            this._layers.buffer = this._createBuffer(layersSize, GPUBufferUsage.STORAGE);
+            this.#layers.buffer = this.#createBuffer(layersSize, GPUBufferUsage.STORAGE);
         }
-
         //--------------------------------------------
-        this._samplers.forEach(sampler => sampler.resource = this._device.createSampler(sampler.descriptor));
+        this.#samplers.forEach(sampler => sampler.resource = this.#device.createSampler(sampler.descriptor));
         //--------------------------------------------
-        this._texturesStorage2d.forEach(textureStorage2d => {
-            textureStorage2d.texture = this._device.createTexture({
-                size: this._presentationSize,
+        this.#texturesStorage2d.forEach(textureStorage2d => {
+            textureStorage2d.texture = this.#device.createTexture({
+                size: this.#presentationSize,
                 format: 'rgba8unorm',
                 usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
             });
         });
         //--------------------------------------------
-        this._textures2d.forEach(texture2d => {
+        this.#textures2d.forEach(texture2d => {
             if (texture2d.imageTexture) {
                 let cubeTexture;
                 const imageBitmap = texture2d.imageTexture.bitmap;
-
-                cubeTexture = this._device.createTexture({
+                cubeTexture = this.#device.createTexture({
                     label: texture2d.name,
                     size: [imageBitmap.width, imageBitmap.height, 1],
                     format: 'rgba8unorm',
@@ -1264,26 +1087,23 @@ export default class Points {
                         GPUTextureUsage.COPY_DST |
                         GPUTextureUsage.RENDER_ATTACHMENT,
                 });
-
-                this._device.queue.copyExternalImageToTexture(
+                this.#device.queue.copyExternalImageToTexture(
                     { source: imageBitmap },
                     { texture: cubeTexture },
                     [imageBitmap.width, imageBitmap.height]
                 );
-
                 texture2d.texture = cubeTexture;
                 // } else if (texture2d.copyCurrentTexture) {
             } else {
-                this._createTextureBindingToCopy(texture2d);
+                this.#createTextureBindingToCopy(texture2d);
             }
         });
         //--------------------------------------------
-        this._textures2dArray.forEach(texture2dArray => {
+        this.#textures2dArray.forEach(texture2dArray => {
             if (texture2dArray.imageTextures) {
                 let cubeTexture;
                 const imageBitmaps = texture2dArray.imageTextures.bitmaps;
-
-                cubeTexture = this._device.createTexture({
+                cubeTexture = this.#device.createTexture({
                     size: [imageBitmaps[0].width, imageBitmaps[0].height, imageBitmaps.length],
                     format: 'rgba8unorm',
                     usage:
@@ -1291,62 +1111,57 @@ export default class Points {
                         GPUTextureUsage.COPY_DST |
                         GPUTextureUsage.RENDER_ATTACHMENT,
                 });
-
                 imageBitmaps.forEach((imageBitmap, i) => {
-                    this._device.queue.copyExternalImageToTexture(
+                    this.#device.queue.copyExternalImageToTexture(
                         { source: imageBitmap },
                         { texture: cubeTexture, origin: { x: 0, y: 0, z: i } },
                         [imageBitmap.width, imageBitmap.height, 1]
                     );
                 })
 
-
                 texture2dArray.texture = cubeTexture;
             } else {
-                this._createTextureBindingToCopy(texture2dArray);
+                this.#createTextureBindingToCopy(texture2dArray);
             }
         });
         //--------------------------------------------
-        this._texturesExternal.forEach(externalTexture => {
-            externalTexture.texture = this._device.importExternalTexture({
+        this.#texturesExternal.forEach(externalTexture => {
+            externalTexture.texture = this.#device.importExternalTexture({
                 source: externalTexture.video
             });
         });
         //--------------------------------------------
-        this._bindingTextures.forEach(bindingTexture => {
-            bindingTexture.texture = this._device.createTexture({
-                size: bindingTexture.size || this._presentationSize,
+        this.#bindingTextures.forEach(bindingTexture => {
+            bindingTexture.texture = this.#device.createTexture({
+                size: bindingTexture.size || this.#presentationSize,
                 format: 'rgba8unorm',
                 usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
             });
         });
     }
 
-    /** @private */
-    _createTextureBindingToCopy(texture2d) {
-        texture2d.texture = this._device.createTexture({
+    #createTextureBindingToCopy(texture2d) {
+        texture2d.texture = this.#device.createTexture({
             label: texture2d.name,
-            size: this._presentationSize,
-            format: this._presentationFormat, // if 'depth24plus' throws error
+            size: this.#presentationSize,
+            format: this.#presentationFormat, // if 'depth24plus' throws error
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
         });
     }
 
-    /** @private */
-    _createTextureToSize(texture2d, width, height) {
-        texture2d.texture = this._device.createTexture({
+    #createTextureToSize(texture2d, width, height) {
+        texture2d.texture = this.#device.createTexture({
             label: texture2d.name,
             size: [width, height],
-            format: this._presentationFormat, // if 'depth24plus' throws error
+            format: this.#presentationFormat, // if 'depth24plus' throws error
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
         });
     }
 
-    /** @private */
-    _createComputeBindGroup() {
-        this._renderPasses.forEach((renderPass, index) => {
+    #createComputeBindGroup() {
+        this.#renderPasses.forEach((renderPass, index) => {
             if (renderPass.hasComputeShader) {
-                const entries = this._createEntries(ShaderType.COMPUTE);
+                const entries = this.#createEntries(ShaderType.COMPUTE);
                 if (entries.length) {
                     let bglEntries = [];
                     entries.forEach((entry, index) => {
@@ -1363,13 +1178,11 @@ export default class Points {
                         }
                         bglEntries.push(bglEntry);
                     });
-
-                    renderPass.bindGroupLayout = this._device.createBindGroupLayout({ entries: bglEntries });
-
+                    renderPass.bindGroupLayout = this.#device.createBindGroupLayout({ entries: bglEntries });
                     /**
                      * @type {GPUBindGroup}
                      */
-                    renderPass.computeBindGroup = this._device.createBindGroup({
+                    renderPass.computeBindGroup = this.#device.createBindGroup({
                         label: `_createComputeBindGroup 0 - ${index}`,
                         layout: renderPass.bindGroupLayout,
                         entries: entries
@@ -1379,20 +1192,17 @@ export default class Points {
         });
     }
 
-    /** @private */
-    async _createPipeline() {
-
-        this._createComputeBindGroup();
-
-        this._renderPasses.forEach((renderPass, index) => {
+    async #createPipeline() {
+        this.#createComputeBindGroup();
+        this.#renderPasses.forEach((renderPass, index) => {
             if (renderPass.hasComputeShader) {
-                renderPass.computePipeline = this._device.createComputePipeline({
-                    layout: this._device.createPipelineLayout({
+                renderPass.computePipeline = this.#device.createComputePipeline({
+                    layout: this.#device.createPipelineLayout({
                         bindGroupLayouts: [renderPass.bindGroupLayout]
                     }),
                     label: `_createPipeline() - ${index}`,
                     compute: {
-                        module: this._device.createShaderModule({
+                        module: this.#device.createShaderModule({
                             code: renderPass.compiledShaders.compute
                         }),
                         entryPoint: "main"
@@ -1401,13 +1211,10 @@ export default class Points {
             }
         });
 
-
         //--------------------------------------
 
-
-        this._createParams();
-
-        //this.createVertexBuffer(new Float32Array(this._vertexArray));
+        this.#createParams();
+        //this.createVertexBuffer(new Float32Array(this.#vertexArray));
         // enum GPUPrimitiveTopology {
         //     'point-list',
         //     'line-list',
@@ -1415,13 +1222,11 @@ export default class Points {
         //     'triangle-list',
         //     'triangle-strip',
         // };
-        this._renderPasses.forEach(renderPass => {
-
+        this.#renderPasses.forEach(renderPass => {
             if (renderPass.hasVertexAndFragmentShader) {
-
-                renderPass.renderPipeline = this._device.createRenderPipeline({
+                renderPass.renderPipeline = this.#device.createRenderPipeline({
                     // layout: 'auto',
-                    layout: this._device.createPipelineLayout({
+                    layout: this.#device.createPipelineLayout({
                         bindGroupLayouts: [renderPass.bindGroupLayout]
                     }),
                     //primitive: { topology: 'triangle-strip' },
@@ -1432,31 +1237,30 @@ export default class Points {
                         format: 'depth24plus',
                     },
                     vertex: {
-                        module: this._device.createShaderModule({
+                        module: this.#device.createShaderModule({
                             code: renderPass.compiledShaders.vertex,
                         }),
                         entryPoint: 'main', // shader function name
-
                         buffers: [
                             {
-                                arrayStride: this._vertexBufferInfo.vertexSize,
+                                arrayStride: this.#vertexBufferInfo.vertexSize,
                                 attributes: [
                                     {
                                         // position
                                         shaderLocation: 0,
-                                        offset: this._vertexBufferInfo.vertexOffset,
+                                        offset: this.#vertexBufferInfo.vertexOffset,
                                         format: 'float32x4',
                                     },
                                     {
                                         // colors
                                         shaderLocation: 1,
-                                        offset: this._vertexBufferInfo.colorOffset,
+                                        offset: this.#vertexBufferInfo.colorOffset,
                                         format: 'float32x4',
                                     },
                                     {
                                         // uv
                                         shaderLocation: 2,
-                                        offset: this._vertexBufferInfo.uvOffset,
+                                        offset: this.#vertexBufferInfo.uvOffset,
                                         format: 'float32x2',
                                     },
                                 ],
@@ -1464,14 +1268,13 @@ export default class Points {
                         ],
                     },
                     fragment: {
-                        module: this._device.createShaderModule({
+                        module: this.#device.createShaderModule({
                             code: renderPass.compiledShaders.fragment,
                         }),
                         entryPoint: 'main', // shader function name
                         targets: [
                             {
-                                format: this._presentationFormat,
-
+                                format: this.#presentationFormat,
                                 blend: {
                                     alpha: {
                                         srcFactor: 'src-alpha',
@@ -1485,34 +1288,29 @@ export default class Points {
                                     },
                                 },
                                 writeMask: GPUColorWrite.ALL,
-
                             },
                         ],
                     },
-
                 });
             }
-
         });
-
     }
-
     /**
      * @private
      * Creates the entries for the pipeline
      * @returns an array with the entries
      */
-    _createEntries(shaderType, internal) {
+    #createEntries(shaderType, internal) {
         internal = internal || false;
         let entries = [];
         let bindingIndex = 0;
-        if (this._uniforms.length) {
+        if (this.#uniforms.length) {
             entries.push(
                 {
                     binding: bindingIndex++,
                     resource: {
                         label: 'uniform',
-                        buffer: this._uniforms.buffer
+                        buffer: this.#uniforms.buffer
                     },
                     type: {
                         name: 'buffer',
@@ -1521,9 +1319,8 @@ export default class Points {
                 }
             );
         }
-
-        if (this._storage.length) {
-            this._storage.forEach(storageItem => {
+        if (this.#storage.length) {
+            this.#storage.forEach(storageItem => {
                 let internalCheck = internal == storageItem.internal;
                 if (!storageItem.shaderType && internalCheck || storageItem.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1542,15 +1339,14 @@ export default class Points {
                 }
             });
         }
-
-        if (this._layers.length) {
-            if (!this._layers.shaderType || this._layers.shaderType == shaderType) {
+        if (this.#layers.length) {
+            if (!this.#layers.shaderType || this.#layers.shaderType == shaderType) {
                 entries.push(
                     {
                         binding: bindingIndex++,
                         resource: {
                             label: 'layer',
-                            buffer: this._layers.buffer
+                            buffer: this.#layers.buffer
                         },
                         type: {
                             name: 'buffer',
@@ -1560,9 +1356,8 @@ export default class Points {
                 );
             }
         }
-
-        if (this._samplers.length) {
-            this._samplers.forEach((sampler, index) => {
+        if (this.#samplers.length) {
+            this.#samplers.forEach((sampler, index) => {
                 let internalCheck = internal == sampler.internal;
                 if (!sampler.shaderType && internalCheck || sampler.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1578,9 +1373,8 @@ export default class Points {
                 }
             });
         }
-
-        if (this._texturesStorage2d.length) {
-            this._texturesStorage2d.forEach((textureStorage2d, index) => {
+        if (this.#texturesStorage2d.length) {
+            this.#texturesStorage2d.forEach((textureStorage2d, index) => {
                 let internalCheck = internal == textureStorage2d.internal;
                 if (!textureStorage2d.shaderType && internalCheck || textureStorage2d.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1597,9 +1391,8 @@ export default class Points {
                 }
             });
         }
-
-        if (this._textures2d.length) {
-            this._textures2d.forEach((texture2d, index) => {
+        if (this.#textures2d.length) {
+            this.#textures2d.forEach((texture2d, index) => {
                 let internalCheck = internal == texture2d.internal;
                 if (!texture2d.shaderType && internalCheck || texture2d.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1616,9 +1409,8 @@ export default class Points {
                 }
             });
         }
-
-        if (this._textures2dArray.length) {
-            this._textures2dArray.forEach((texture2dArray, index) => {
+        if (this.#textures2dArray.length) {
+            this.#textures2dArray.forEach((texture2dArray, index) => {
                 let internalCheck = internal == texture2dArray.internal;
                 if (!texture2dArray.shaderType && internalCheck || texture2dArray.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1640,9 +1432,8 @@ export default class Points {
                 }
             });
         }
-
-        if (this._texturesExternal.length) {
-            this._texturesExternal.forEach(externalTexture => {
+        if (this.#texturesExternal.length) {
+            this.#texturesExternal.forEach(externalTexture => {
                 let internalCheck = internal == externalTexture.internal;
                 if (!externalTexture.shaderType && internalCheck || externalTexture.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1659,9 +1450,8 @@ export default class Points {
                 }
             });
         }
-
-        if (this._bindingTextures.length) {
-            this._bindingTextures.forEach(bindingTexture => {
+        if (this.#bindingTextures.length) {
+            this.#bindingTextures.forEach(bindingTexture => {
                 let internalCheck = internal == bindingTexture.internal;
                 if (bindingTexture.compute.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1678,8 +1468,7 @@ export default class Points {
                     );
                 }
             });
-
-            this._bindingTextures.forEach(bindingTexture => {
+            this.#bindingTextures.forEach(bindingTexture => {
                 let internalCheck = internal == bindingTexture.internal;
                 if (bindingTexture.fragment.shaderType == shaderType && internalCheck) {
                     entries.push(
@@ -1696,26 +1485,20 @@ export default class Points {
                 }
             });
         }
-
         return entries;
     }
 
-    /** @private */
-    _createParams() {
-        this._renderPasses.forEach(renderPass => {
-
-            const entries = this._createEntries(ShaderType.FRAGMENT, renderPass.internal);
+    #createParams() {
+        this.#renderPasses.forEach(renderPass => {
+            const entries = this.#createEntries(ShaderType.FRAGMENT, renderPass.internal);
             if (entries.length) {
-
                 let bglEntries = [];
                 entries.forEach((entry, index) => {
                     let bglEntry = {
                         binding: index,
                         visibility: GPUShaderStage.FRAGMENT
                     }
-
                     bglEntry[entry.type.name] = { 'type': entry.type.type };
-
                     if (entry.type.viewDimension) {
                         bglEntry[entry.type.name].viewDimension = entry.type.viewDimension
                     }
@@ -1728,80 +1511,65 @@ export default class Points {
                     if (entry.type.type == 'uniform') {
                         bglEntry.visibility = GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT
                     }
-
                     bglEntries.push(bglEntry);
                 });
-
-                renderPass.bindGroupLayout = this._device.createBindGroupLayout({ entries: bglEntries });
-
-                renderPass.uniformBindGroup = this._device.createBindGroup({
+                renderPass.bindGroupLayout = this.#device.createBindGroupLayout({ entries: bglEntries });
+                renderPass.uniformBindGroup = this.#device.createBindGroup({
                     label: '_createParams() 0',
                     layout: renderPass.bindGroupLayout,
                     entries: entries
                 });
             }
         });
-
     }
-
     async update() {
-        if (!this._canvas || !this._device) return;
-
+        if (!this.#canvas || !this.#device) return;
         //--------------------------------------------
-        this._delta = this._clock.getDelta();
-        this._time = this._clock.time;
-        this._epoch = new Date() / 1000;
-        this.setUniform(UniformKeys.TIME, this._time);
-        this.setUniform(UniformKeys.DELTA, this._delta);
-        this.setUniform(UniformKeys.EPOCH, this._epoch);
-        this.setUniform(UniformKeys.SCREEN, [this._canvas.width, this._canvas.height]);
-        this.setUniform(UniformKeys.MOUSE, [this._mouseX, this._mouseY]);
-
-        this.setUniform(UniformKeys.MOUSE_CLICK, this._mouseClick);
-        this.setUniform(UniformKeys.MOUSE_DOWN, this._mouseDown);
-        this.setUniform(UniformKeys.MOUSE_WHEEL, this._mouseWheel);
-        this.setUniform(UniformKeys.MOUSE_DELTA, this._mouseDelta);
+        this.#delta = this.#clock.getDelta();
+        this.#time = this.#clock.time;
+        this.#epoch = new Date() / 1000;
+        this.setUniform(UniformKeys.TIME, this.#time);
+        this.setUniform(UniformKeys.DELTA, this.#delta);
+        this.setUniform(UniformKeys.EPOCH, this.#epoch);
+        this.setUniform(UniformKeys.SCREEN, [this.#canvas.width, this.#canvas.height]);
+        this.setUniform(UniformKeys.MOUSE, [this.#mouseX, this.#mouseY]);
+        this.setUniform(UniformKeys.MOUSE_CLICK, this.#mouseClick);
+        this.setUniform(UniformKeys.MOUSE_DOWN, this.#mouseDown);
+        this.setUniform(UniformKeys.MOUSE_WHEEL, this.#mouseWheel);
+        this.setUniform(UniformKeys.MOUSE_DELTA, this.#mouseDelta);
         //--------------------------------------------
-
-        this._createParametersUniforms();
-
+        this.#createParametersUniforms();
         // TODO: create method for this
-        this._storage.forEach(storageItem => {
+        this.#storage.forEach(storageItem => {
             if (storageItem.mapped) {
                 const values = new Float32Array(storageItem.array);
-                storageItem.buffer = this._createAndMapBuffer(values, storageItem.usage);
+                storageItem.buffer = this.#createAndMapBuffer(values, storageItem.usage);
             }
         });
-
         // AUDIO
-        // this._analyser.getByteTimeDomainData(this._dataArray);
-        this._sounds.forEach(sound => {
+        // this.#analyser.getByteTimeDomainData(this.#dataArray);
+        this.#sounds.forEach(sound => {
             sound.analyser?.getByteFrequencyData(sound.data);
         });
         // END AUDIO
-
-        this._texturesExternal.forEach(externalTexture => {
-            externalTexture.texture = this._device.importExternalTexture({
+        this.#texturesExternal.forEach(externalTexture => {
+            externalTexture.texture = this.#device.importExternalTexture({
                 source: externalTexture.video
             });
-
             if ('requestVideoFrameCallback' in externalTexture.video) {
                 externalTexture.video.requestVideoFrameCallback(() => { });
             }
         });
 
+        this.#createComputeBindGroup();
 
-        this._createComputeBindGroup();
+        let commandEncoder = this.#device.createCommandEncoder();
 
-
-        let commandEncoder = this._device.createCommandEncoder();
-
-
-        this._renderPasses.forEach(renderPass => {
+        this.#renderPasses.forEach(renderPass => {
             if (renderPass.hasComputeShader) {
                 const passEncoder = commandEncoder.beginComputePass();
                 passEncoder.setPipeline(renderPass.computePipeline);
-                if (this._uniforms.length) {
+                if (this.#uniforms.length) {
                     passEncoder.setBindGroup(0, renderPass.computeBindGroup);
                 }
                 passEncoder.dispatchWorkgroups(
@@ -1813,29 +1581,23 @@ export default class Points {
             }
         });
 
-
         // ---------------------
 
+        this.#renderPassDescriptor.colorAttachments[0].view = this.#context.getCurrentTexture().createView();
+        this.#renderPassDescriptor.depthStencilAttachment.view = this.#depthTexture.createView();
 
-        this._renderPassDescriptor.colorAttachments[0].view = this._context.getCurrentTexture().createView();
-        this._renderPassDescriptor.depthStencilAttachment.view = this._depthTexture.createView();
+        const swapChainTexture = this.#context.getCurrentTexture();
 
-
-        const swapChainTexture = this._context.getCurrentTexture();
-
-
-        //commandEncoder = this._device.createCommandEncoder();
-        this._renderPasses.forEach((renderPass, renderPassIndex) => {
+        //commandEncoder = this.#device.createCommandEncoder();
+        this.#renderPasses.forEach((renderPass, renderPassIndex) => {
             if (renderPass.hasVertexAndFragmentShader) {
-                const passEncoder = commandEncoder.beginRenderPass(this._renderPassDescriptor);
+                const passEncoder = commandEncoder.beginRenderPass(this.#renderPassDescriptor);
                 passEncoder.setPipeline(renderPass.renderPipeline);
-
-                this._createParams();
-                if (this._uniforms.length) {
+                this.#createParams();
+                if (this.#uniforms.length) {
                     passEncoder.setBindGroup(0, renderPass.uniformBindGroup);
                 }
-                passEncoder.setVertexBuffer(0, this._buffer);
-
+                passEncoder.setVertexBuffer(0, this.#buffer);
                 /**
                  * vertexCount: number The number of vertices to draw
                  * instanceCount?: number | undefined The number of instances to draw
@@ -1843,12 +1605,10 @@ export default class Points {
                  * firstInstance?: number | undefined First instance to draw
                  */
                 //passEncoder.draw(3, 1, 0, 0);
-                passEncoder.draw(this._vertexBufferInfo.vertexCount);
+                passEncoder.draw(this.#vertexBufferInfo.vertexCount);
                 passEncoder.end();
-
                 // Copy the rendering results from the swapchain into |texture2d.texture|.
-
-                this._textures2d.forEach(texture2d => {
+                this.#textures2d.forEach(texture2d => {
                     if (texture2d.renderPassIndex == renderPassIndex || texture2d.renderPassIndex == null) {
                         if (texture2d.copyCurrentTexture) {
                             commandEncoder.copyTextureToTexture(
@@ -1858,15 +1618,14 @@ export default class Points {
                                 {
                                     texture: texture2d.texture,
                                 },
-                                this._presentationSize
+                                this.#presentationSize
                             );
                         }
                     }
                 });
-
-                this._texturesToCopy.forEach(texturePair => {
+                this.#texturesToCopy.forEach(texturePair => {
                     // console.log(texturePair.a);
-                    // this._createTextureToSize(texturePair.b, texturePair.a.width, texturePair.a.height);
+                    // this.#createTextureToSize(texturePair.b, texturePair.a.width, texturePair.a.height);
                     commandEncoder.copyTextureToTexture(
                         {
                             texture: texturePair.a,
@@ -1877,17 +1636,15 @@ export default class Points {
                         [texturePair.a.width, texturePair.a.height]
                     );
                 });
-                this._texturesToCopy = [];
+                this.#texturesToCopy = [];
             }
         });
 
 
 
-
-        if (this._readStorage.length) {
-            this._readStorage.forEach(readStorageItem => {
-                let storageItem = this._storage.find(storageItem => storageItem.name === readStorageItem.name);
-
+        if (this.#readStorage.length) {
+            this.#readStorage.forEach(readStorageItem => {
+                let storageItem = this.#storage.find(storageItem => storageItem.name === readStorageItem.name);
                 commandEncoder.copyBufferToBuffer(
                     storageItem.buffer /* source buffer */,
                     0 /* source offset */,
@@ -1897,26 +1654,20 @@ export default class Points {
                 );
             });
         }
-
         // ---------------------
-
-        this._commandsFinished.push(commandEncoder.finish());
-        this._device.queue.submit(this._commandsFinished);
-        this._commandsFinished = [];
-
+        this.#commandsFinished.push(commandEncoder.finish());
+        this.#device.queue.submit(this.#commandsFinished);
+        this.#commandsFinished = [];
         //
-        //this._vertexArray = [];
-
+        //this.#vertexArray = [];
         // reset mouse values because it doesn't happen by itself
-        this._mouseClick = false;
-        this._mouseWheel = false;
-        this._mouseDelta = [0, 0];
-
+        this.#mouseClick = false;
+        this.#mouseWheel = false;
+        this.#mouseDelta = [0, 0];
         await this.read();
     }
-
     async read() {
-        for (const [key, event] of this._events) {
+        for (const [key, event] of this.#events) {
             let eventRead = await this.readStorage(event.name);
             if (eventRead) {
                 let id = eventRead[0];
@@ -1927,13 +1678,11 @@ export default class Points {
         }
     }
 
-    /** @private */
-    _getWGSLCoordinate(value, side, invert = false) {
+    #getWGSLCoordinate(value, side, invert = false) {
         const direction = invert ? -1 : 1;
         const p = value / side;
         return (p * 2 - 1) * direction;
     };
-
     /**
      * Adds two triangles as a quad called Point
      * @param {Coordinate} coordinate `x` from 0 to canvas.width, `y` from 0 to canvas.height, `z` it goes from 0.0 to 1.0 and forward
@@ -1944,83 +1693,70 @@ export default class Points {
      */
     addPoint(coordinate, width, height, colors) {
         const { x, y, z } = coordinate;
-        const nx = this._getWGSLCoordinate(x, this._canvas.width);
-        const ny = this._getWGSLCoordinate(y, this._canvas.height, true);
+        const nx = this.#getWGSLCoordinate(x, this.#canvas.width);
+        const ny = this.#getWGSLCoordinate(y, this.#canvas.height, true);
         const nz = z;
-
-        const nw = this._getWGSLCoordinate(x + width, this._canvas.width);
-        const nh = this._getWGSLCoordinate(y + height, this._canvas.height);
-
+        const nw = this.#getWGSLCoordinate(x + width, this.#canvas.width);
+        const nh = this.#getWGSLCoordinate(y + height, this.#canvas.height);
         const { r: r0, g: g0, b: b0, a: a0 } = colors[0];
         const { r: r1, g: g1, b: b1, a: a1 } = colors[1];
         const { r: r2, g: g2, b: b2, a: a2 } = colors[2];
         const { r: r3, g: g3, b: b3, a: a3 } = colors[3];
-        this._vertexArray.push(
+        this.#vertexArray.push(
             +nx, +ny, nz, 1, r0, g0, b0, a0, (+nx + 1) * .5, (+ny + 1) * .5,// 0 top left
             +nw, +ny, nz, 1, r1, g1, b1, a1, (+nw + 1) * .5, (+ny + 1) * .5,// 1 top right
             +nw, -nh, nz, 1, r3, g3, b3, a3, (+nw + 1) * .5, (-nh + 1) * .5,// 2 bottom right
-
             +nx, +ny, nz, 1, r0, g0, b0, a0, (+nx + 1) * .5, (+ny + 1) * .5,// 3 top left
             +nx, -nh, nz, 1, r2, g2, b2, a2, (+nx + 1) * .5, (-nh + 1) * .5,// 4 bottom left
             +nw, -nh, nz, 1, r3, g3, b3, a3, (+nw + 1) * .5, (-nh + 1) * .5,// 5 bottom right
         );
     }
-
     get canvas() {
-        return this._canvas;
+        return this.#canvas;
     }
-
     get device() {
-        return this._device;
+        return this.#device;
     }
-
     get context() {
-        return this._context;
+        return this.#context;
     }
-
     get presentationFormat() {
-        return this._presentationFormat;
+        return this.#presentationFormat;
     }
-
     get buffer() {
-        return this._buffer;
+        return this.#buffer;
     }
-
     get fullscreen() {
-        return this._fullscreen;
+        return this.#fullscreen;
     }
-
     set fullscreen(value) {
         if (value) {
-            this._lastFitWindow = this._fitWindow;
+            this.#lastFitWindow = this.#fitWindow;
             this.fitWindow = value;
-            this._canvas.requestFullscreen().catch(err => {
+            this.#canvas.requestFullscreen().catch(err => {
                 throw `Error attempting to enable fullscreen mode: ${err.message} (${err.name})`;
             });
-            this._fullscreen = true;
+            this.#fullscreen = true;
         } else {
             document.exitFullscreen();
-            this._fullscreen = false;
-            this._resizeCanvasToDefault();
+            this.#fullscreen = false;
+            this.#resizeCanvasToDefault();
         }
     }
-
     get fitWindow() {
-        return this._fitWindow;
+        return this.#fitWindow;
     }
-
     set fitWindow(value) {
-        if (!this._context) {
+        if (!this.#context) {
             throw 'fitWindow must be assigned after Points.init() call or you don\'t have a Canvas assigned in the constructor';
         }
-        this._fitWindow = value;
-        if (this._fitWindow) {
-            this._resizeCanvasToFitWindow();
+        this.#fitWindow = value;
+        if (this.#fitWindow) {
+            this.#resizeCanvasToFitWindow();
         } else {
-            this._resizeCanvasToDefault();
+            this.#resizeCanvasToDefault();
         }
     }
-
     // -----------------------------
     videoStream = null;
     mediaRecorder = null;
@@ -2030,9 +1766,8 @@ export default class Points {
             videoBitsPerSecond: 6000000,
             mimeType: 'video/webm',
         };
-        this.videoStream = this._canvas.captureStream(60);
+        this.videoStream = this.#canvas.captureStream(60);
         this.mediaRecorder = new MediaRecorder(this.videoStream, options);
-
         let chunks = [];
         this.mediaRecorder.ondataavailable = function (e) {
             chunks.push(e.data);
@@ -2046,10 +1781,8 @@ export default class Points {
         this.mediaRecorder.ondataavailable = function (e) {
             chunks.push(e.data);
         };
-
         this.mediaRecorder.start();
     }
-
     videoRecordStop() {
         this.mediaRecorder.stop();
     }

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -590,8 +590,11 @@ export default class Points {
      * @param {Array} paths
      * @param {ShaderType} shaderType
      */
+    // TODO: verify if this can be updated after creation
+    // TODO: return texture2dArray object
     async setTextureImageArray(name, paths, shaderType) {
         if (this.#nameExists(this.#textures2dArray, name)) {
+            // TODO: throw exception here
             return;
         }
         const imageBitmaps = [];

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -249,8 +249,8 @@ export default class Points {
     }
 
     /**
-     * 
-     * @param {Array} arr 
+     *
+     * @param {Array} arr
      */
     updateUniforms(arr) {
         arr.forEach(uniform => {
@@ -422,6 +422,42 @@ export default class Points {
             },
             internal: this._internal
         });
+    }
+
+    /**
+     * Load an image as texture_2d
+     * @param {string} name
+     * @param {string} path
+     * @param {ShaderType} shaderType
+     */
+    async updateTextureImage(name, path, shaderType) {
+        if (!this._nameExists(this._textures2d, name)) {
+            console.warn('image can not be updated')
+            return;
+        }
+
+        const response = await fetch(path);
+        const blob = await response.blob();
+        const imageBitmap = await createImageBitmap(blob);
+
+        const texture2d = this._textures2d.filter(obj => obj.name == name)[0];
+        texture2d.imageTexture.bitmap = imageBitmap;
+
+        const cubeTexture = this._device.createTexture({
+            size: [imageBitmap.width, imageBitmap.height, 1],
+            format: 'rgba8unorm',
+            usage:
+                GPUTextureUsage.TEXTURE_BINDING |
+                GPUTextureUsage.COPY_DST |
+                GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+
+        this._device.queue.copyExternalImageToTexture(
+            { source: imageBitmap },
+            { texture: cubeTexture },
+            [imageBitmap.width, imageBitmap.height]
+        );
+        texture2d.texture = cubeTexture;
     }
 
     /**

--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -11,6 +11,7 @@ import { dataSize, getArrayTypeData, isArray, typeSizes } from './data-size.js';
 
 export default class Points {
     constructor(canvasId) {
+        // TODO: change @private and _var to #var in all uses even private methods
         /** @private */
         this._canvasId = canvasId;
         /** @private */
@@ -281,6 +282,7 @@ export default class Points {
      * Update a list of uniforms
      * @param {Array<Object>} array object array of the type: `{name, value}`
      */
+    // TODO: change to setUniforms
     updateUniforms(arr) {
         arr.forEach(uniform => {
             const variable = this._uniforms.find(v => v.name === uniform.name);
@@ -408,6 +410,7 @@ export default class Points {
         return arrayBufferCopy;
     }
 
+    // TODO: change to setLayers
     addLayers(numLayers, shaderType) {
         for (let layerIndex = 0; layerIndex < numLayers; layerIndex++) {
             this._layers.shaderType = shaderType;
@@ -433,6 +436,7 @@ export default class Points {
      * @param {string} name Name of the `sampler` to be called in the shaders.
      * @param {GPUSamplerDescriptor} descriptor
      */
+    // TODO: change to setSampler
     addSampler(name, descriptor, shaderType) {
         if ('sampler' == name) {
             throw '`name` can not be sampler since is a WebGPU keyword';
@@ -466,6 +470,7 @@ export default class Points {
      * @param {string} name Name to call the texture in the shaders.
      * @param {boolean} copyCurrentTexture If you want the fragment output to be copied here.
      */
+    // TODO: change to setTexture2d
     addTexture2d(name, copyCurrentTexture, shaderType, renderPassIndex) {
         if (this._nameExists(this._textures2d, name)) {
             return;
@@ -503,7 +508,7 @@ export default class Points {
     }
 
     /**
-     * @deprecated uset setTextureImage
+     * @deprecated use setTextureImage
      */
     async addTextureImage(name, path, shaderType) {
         if (this._nameExists(this._textures2d, name)) {
@@ -649,6 +654,7 @@ export default class Points {
      * @param {string} path
      * @param {ShaderType} shaderType
      */
+    // TODO: change to setTextureVideo
     async addTextureVideo(name, path, shaderType) {
         if (this._nameExists(this._texturesExternal, name)) {
             return;
@@ -668,6 +674,7 @@ export default class Points {
         });
     }
 
+    // TODO: change to setTextureWebcam
     async addTextureWebcam(name, shaderType) {
         if (this._nameExists(this._texturesExternal, name)) {
             return;
@@ -697,6 +704,7 @@ export default class Points {
         });
     }
 
+    // TODO: change to setAudio
     addAudio(name, path, volume, loop, autoplay) {
         const audio = new Audio(path);
         audio.volume = volume;
@@ -737,7 +745,7 @@ export default class Points {
         analyser.getByteFrequencyData(data);
 
         // storage that will have the data on WGSL
-        this.addStorageMap(name, data,
+        this.setStorageMap(name, data,
             // `array<f32, ${bufferLength}>`
             'Sound' // custom struct in defaultStructs.js
         );
@@ -752,6 +760,7 @@ export default class Points {
     }
 
     // TODO: verify this method
+    // TODO: change to setTextureStorage2d
     addTextureStorage2d(name, shaderType) {
         if (this._nameExists(this._texturesStorage2d, name)) {
             return;
@@ -773,6 +782,7 @@ export default class Points {
      * @param {Array<number, 2>} size dimensions of the texture, by default screen
      * size
      */
+    // TODO: change to setBindingTexture
     addBindingTexture(computeName, fragmentName, size) {
         this._bindingTextures.push({
             compute: {
@@ -798,7 +808,7 @@ export default class Points {
         // TODO: remove structSize
         // this extra 4 is for the boolean flag in the Event struct
         let data = Array(structSize + 4).fill(0);
-        this.addStorageMap(name, data, 'Event', true);
+        this.setStorageMap(name, data, 'Event', true);
         this._events.set(this._events_ids,
             {
                 id: this._events_ids,

--- a/src/clock.js
+++ b/src/clock.js
@@ -3,12 +3,11 @@
  * based on https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js
  */
 export default class Clock {
-
+    #time = 0;
+    #oldTime = 0;
+    #delta = 0;
     constructor() {
-        /** @private */
-        this._time = 0;
-        /** @private */
-        this._oldTime = 0;
+
     }
 
     /**
@@ -16,18 +15,17 @@ export default class Clock {
      *  when `getDelta()` is called.
      */
     get time() {
-        return this._time;
+        return this.#time;
     }
 
     /**
      * Gets the last delta value, it does not calculate the delta, use `getDelta()`
      */
     get delta() {
-        return this._delta;
+        return this.#delta;
     }
 
-    /** @private */
-    now() {
+    #now() {
         return (typeof performance === 'undefined' ? Date : performance).now();
     }
 
@@ -36,11 +34,11 @@ export default class Clock {
      * It also calculates `time`
      */
     getDelta() {
-        this._delta = 0;
-        const newTime = this.now();
-        this._delta = (newTime - this._oldTime) / 1000;
-        this._oldTime = newTime;
-        this._time += this._delta;
-        return this._delta;
+        this.#delta = 0;
+        const newTime = this.#now();
+        this.#delta = (newTime - this.#oldTime) / 1000;
+        this.#oldTime = newTime;
+        this.#time += this.#delta;
+        return this.#delta;
     }
 }

--- a/src/color.js
+++ b/src/color.js
@@ -1,4 +1,5 @@
 class RGBAColor {
+    #value;
     constructor(r = 0, g = 0, b = 0, a = 1) {
         if (r > 1 && g > 1 && b > 1) {
             r /= 255;
@@ -8,43 +9,43 @@ class RGBAColor {
                 a /= 255;
             }
         }
-        this._value = [r, g, b, a];
+        this.#value = [r, g, b, a];
     }
 
     set r(value) {
-        this._value[0] = value;
+        this.#value[0] = value;
     }
 
     set g(value) {
-        this._value[1] = value;
+        this.#value[1] = value;
     }
 
     set b(value) {
-        this._value[2] = value;
+        this.#value[2] = value;
     }
 
     set a(value) {
-        this._value[3] = value;
+        this.#value[3] = value;
     }
 
     get r() {
-        return this._value[0];
+        return this.#value[0];
     }
 
     get g() {
-        return this._value[1];
+        return this.#value[1];
     }
 
     get b() {
-        return this._value[2];
+        return this.#value[2];
     }
 
     get a() {
-        return this._value[3];
+        return this.#value[3];
     }
 
     get value() {
-        return this._value;
+        return this.#value;
     }
 
     get brightness() {
@@ -56,33 +57,33 @@ class RGBAColor {
         // LuminanceC = sqrt(0.299*(R**2) + 0.587*(G**2) + 0.114*(B**2))
 
 
-        let [r, g, b, a] = this._value;
+        let [r, g, b, a] = this.#value;
         return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
     }
 
     set brightness(value) {
-        this._value = [value, value, value, 1];
+        this.#value = [value, value, value, 1];
     }
 
     set(r, g, b, a) {
-        this._value = [r, g, b, a]
+        this.#value = [r, g, b, a]
     }
 
     setColor(color) {
-        this._value = [color.r, color.g, color.b, color.a];
+        this.#value = [color.r, color.g, color.b, color.a];
     }
 
     add(color) {
-        let [r, g, b, a] = this._value;
-        //this._value = [(r + color.r)/2, (g + color.g)/2, (b + color.b)/2, (a + color.a)/2];
-        //this._value = [(r*a + color.r*color.a), (g*a + color.g*color.a), (b*a + color.b*color.a), 1];
-        this._value = [(r + color.r), (g + color.g), (b + color.b), (a + color.a)];
+        let [r, g, b, a] = this.#value;
+        //this.#value = [(r + color.r)/2, (g + color.g)/2, (b + color.b)/2, (a + color.a)/2];
+        //this.#value = [(r*a + color.r*color.a), (g*a + color.g*color.a), (b*a + color.b*color.a), 1];
+        this.#value = [(r + color.r), (g + color.g), (b + color.b), (a + color.a)];
 
 
     }
 
     blend(color) {
-        let [r0, g0, b0, a0] = this._value;
+        let [r0, g0, b0, a0] = this.#value;
         let [r1, b1, g1, a1] = color.value;
 
         let a01 = (1 - a0) * a1 + a0
@@ -93,13 +94,13 @@ class RGBAColor {
 
         let b01 = ((1 - a0) * a1 * b1 + a0 * b0) / a01
 
-        this._value = [r01, g01, b01, a01];
+        this.#value = [r01, g01, b01, a01];
     }
 
 
     additive(color) {
         // https://gist.github.com/JordanDelcros/518396da1c13f75ee057
-        let base = this._value;
+        let base = this.#value;
         let added = color.value;
 
         let mix = [];
@@ -108,11 +109,11 @@ class RGBAColor {
         mix[1] = Math.round((added[1] * added[3] / mix[3]) + (base[1] * base[3] * (1 - added[3]) / mix[3])); // green
         mix[2] = Math.round((added[2] * added[3] / mix[3]) + (base[2] * base[3] * (1 - added[3]) / mix[3])); // blue
 
-        this._value = mix;
+        this.#value = mix;
     }
 
     equal(color) {
-        return (this._value[0] == color.r) && (this._value[1] == color.g) && (this._value[2] == color.b) && (this._value[3] == color.a);
+        return (this.#value[0] == color.r) && (this.#value[1] == color.g) && (this.#value[2] == color.b) && (this.#value[3] == color.a);
     }
 
 
@@ -152,7 +153,7 @@ class RGBAColor {
     }
 
     isNull() {
-        const [r, g, b, a] = this._value;
+        const [r, g, b, a] = this.#value;
         return !(isNaN(r) && isNaN(g) && isNaN(b) && isNaN(a))
     }
 
@@ -168,7 +169,7 @@ class RGBAColor {
      * @returns Number distace up to `1.42` I think...
      */
     euclideanDistance(color) {
-        const [r, g, b] = this._value;
+        const [r, g, b] = this.#value;
         return Math.sqrt(Math.pow(r - color.r, 2) +
             Math.pow(g - color.g, 2) +
             Math.pow(b - color.b, 2));

--- a/src/coordinate.js
+++ b/src/coordinate.js
@@ -1,49 +1,53 @@
 class Coordinate {
+    #x;
+    #y;
+    #z;
+    #value;
     constructor(x = 0, y = 0, z = 0) {
-        this._x = x;
-        this._y = y;
-        this._z = z;
-        this._value = [x, y, z];
+        this.#x = x;
+        this.#y = y;
+        this.#z = z;
+        this.#value = [x, y, z];
     }
 
     set x(value) {
-        this._x = value;
-        this._value[0] = value;
+        this.#x = value;
+        this.#value[0] = value;
     }
 
     set y(value) {
-        this._y = value;
-        this._value[1] = value;
+        this.#y = value;
+        this.#value[1] = value;
     }
 
     set z(value) {
-        this._z = value;
-        this._value[2] = value;
+        this.#z = value;
+        this.#value[2] = value;
     }
 
     get x() {
-        return this._x;
+        return this.#x;
     }
 
     get y() {
-        return this._y;
+        return this.#y;
     }
 
     get z() {
-        return this._z;
+        return this.#z;
     }
 
     get value() {
-        return this._value;
+        return this.#value;
     }
 
     set(x, y, z) {
-        this._x = x;
-        this._y = y;
-        this._z = z;
-        this._value[0] = x;
-        this._value[1] = y;
-        this._value[2] = z;
+        this.#x = x;
+        this.#y = y;
+        this.#z = z;
+        this.#value[0] = x;
+        this.#value[1] = y;
+        this.#value[2] = z;
     }
 }
 


### PR DESCRIPTION
Added texture arrays with a bunch of updates like:

- Methods starting with add* and update* have been renamed to set*, this to avoid ambiguity, a set rename works in the same way as a variable assignment, and with an assignment you can do an update of the same variable, hence the rename.
- Private properties: using the JavaScript support for private properties and methods starting with the **#** symbol
- Texture Arrays allow the creation of a variable on the wgsl side with a layered texture and accessed via an index which is super convenient