### PR TITLE
Screen centered in examples

### DIFF
--- a/src/absulit.points.module.js
+++ b/src/absulit.points.module.js
@@ -94,8 +94,9 @@ export default class Points {
 
     #resizeCanvasToFitWindow = () => {
         if (this.#fitWindow) {
-            this.#canvas.width = window.innerWidth;
-            this.#canvas.height = window.innerHeight;
+            const {offsetWidth, offsetHeight} = this.#canvas.parentNode;
+            this.#canvas.width = offsetWidth;
+            this.#canvas.height = offsetHeight;
             this.#setScreenSize();
         }
     }


### PR DESCRIPTION
- The width of the container was not being taken into account, but the full window innerWidth and innerHeight, so now we use the parent container of the canvas for this.