### PR TITLE
Renderpass unification

### DIFF
--- a/src/points.js
+++ b/src/points.js
@@ -1466,20 +1466,18 @@ class Points {
         }
 
         // TODO: this should be inside RenderPass, to not call vertexArray outside
-        this.#renderPasses.forEach(r => {
+        this.#renderPasses.forEach((r, i) => {
             r.init?.(this);
             r.meshes.forEach(mesh => this.#setMeshUniform(mesh.name, mesh.id, 'u32'));
-            // this is the same as this.#renderPasses.forEach(this.#compileRenderPass);
-            // but it doesn't work inside this loop, maybe for later
-            // this.#compileRenderPass(r);
 
             this.createScreen(r);
             r.vertexBufferInfo = new VertexBufferInfo(r.vertexArray);
             r.vertexBuffer = this.#createAndMapBuffer(r.vertexArray, GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST);
-        });
-        this.#renderPasses.forEach(this.#compileRenderPass); // this.#compileRenderPass(r);
-        this.#generateDataSize();
 
+            this.#compileRenderPass(r, i);
+        });
+
+        this.#generateDataSize();
         this.#createBuffers();
         this.#createPipeline();
 


### PR DESCRIPTION
- Removed a few forEach loops and merge them together.
- Wanted to remove another one but it breaks the code.
- The loop iterates over the RenderPass list, so depending on the actual amount of RenderPass in the final app, this then would be a little bit faster to initialize.