### PR TITLE
277 uniforms update can use var  value

### DIFF
--- a/examples/glb2/glb_renderpass/vert.js
+++ b/examples/glb2/glb_renderpass/vert.js
@@ -10,7 +10,7 @@ ${rotZAxis}
 fn main(in: VertexIn) -> FragmentIn {
     let particle = particles[in.instanceIndex];
     // var angleZ = params.time * 0.9854;
-    var angleY = params.time * 0.094222;
+    let angleY = params.angleY;
     // var angleX = params.time * 0.865;
 
     let rotX = rotXAxis(0);

--- a/examples/glb2/index.js
+++ b/examples/glb2/index.js
@@ -111,17 +111,19 @@ const base = {
 
         points.setCameraPerspective('camera');
 
+        points.setUniform('angleY', 0);
 
         folder.open();
     },
     /**
      * @param {Points} points
      */
-    update: points => {
+    update: (points, t, dt) => {
 
         points.setCameraPerspective('camera', [0, 0, 5], [0, 0, -1000]);
 
         points.setUniform('dof', options.dof);
+        points.params.angleY.value += dt * 0.094222;
     }
 }
 

--- a/src/points.js
+++ b/src/points.js
@@ -98,6 +98,8 @@ class Points {
     #canvasWidth = null;
     #canvasHeight = null;
 
+    #params = {}
+
     /**
      * Constructor of `Points`.
      * Set a width and height to be used if no `fitWindow` is called, and also
@@ -320,12 +322,13 @@ class Points {
             throw `${structName} is an array, which is currently not supported for Uniforms.`;
         }
         const uniform = {
-            name: name,
-            value: value,
+            name,
+            value,
             type: structName,
             size: null
         }
         Object.seal(uniform);
+        this.#params[name] = uniform;
         this.#uniforms.push(uniform);
         return uniform;
     }

--- a/src/points.js
+++ b/src/points.js
@@ -198,7 +198,7 @@ class Points {
         this.#canvas.height = this.#canvas.clientHeight;
         this.#screen[0] = this.#canvas.width;
         this.#screen[1] = this.#canvas.height;
-        this.setUniform(UniformKeys.SCREEN, this.#screen);
+        this.#params.screen.value = this.#screen
 
         this.#presentationSize = [
             this.#canvas.clientWidth,
@@ -265,7 +265,7 @@ class Points {
         this.#ratio[0] = ratio[0];
         this.#ratio[1] = ratio[1];
 
-        this.setUniform(UniformKeys.RATIO, this.#ratio);
+        this.#params.ratio.value = this.#ratio;
     }
 
     #onMouseMove = e => {
@@ -278,8 +278,9 @@ class Points {
         this.#mouseNormalized[0] = this.#mouse[0] / this.#screen[0];
         this.#mouseNormalized[1] = this.#mouse[1] / this.#screen[1];
         this.#mouseNormalized[1] = (this.#mouseNormalized[1] * - 1) - -1; // flip and move up
-        this.setUniform(UniformKeys.MOUSE, this.#mouse);
-        this.setUniform('_mouse_normalized', this.#mouseNormalized);
+
+        this.#params.mouse.value = this.#mouse;
+        this.#params._mouse_normalized.value = this.#mouseNormalized;
     }
 
     /**
@@ -387,7 +388,7 @@ class Points {
      */
     updateUniforms(arr) {
         arr.forEach(uniform => {
-            const variable = this.#uniforms.find(v => v.name === uniform.name);
+            const variable = this.#params[uniform.name];
             if (!variable) {
                 throw '`updateUniform()` can\'t be called without first `setUniform()`.';
             }
@@ -2567,9 +2568,10 @@ class Points {
         this.#delta = this.#clock.getDelta();
         this.#time = this.#clock.time;
         this.#epoch = +new Date() / 1000;
-        this.setUniform(UniformKeys.TIME, this.#time);
-        this.setUniform(UniformKeys.DELTA, this.#delta);
-        this.setUniform(UniformKeys.EPOCH, this.#epoch);
+
+        this.#params.delta.value = this.#delta;
+        this.#params.time.value = this.#time;
+        this.#params.epoch.value = this.#epoch;
         //--------------------------------------------
         this.#writeParametersUniforms();
         this.#writeStorages();
@@ -2770,9 +2772,10 @@ class Points {
         this.#mouseWheel = false;
         this.#mouseDelta[0] = 0;
         this.#mouseDelta[1] = 0;
-        this.setUniform(UniformKeys.MOUSE_CLICK, this.#mouseClick);
-        this.setUniform(UniformKeys.MOUSE_WHEEL, this.#mouseWheel);
-        this.setUniform(UniformKeys.MOUSE_DELTA, this.#mouseDelta);
+
+        this.#params.mouseClick.value = this.#mouseClick;
+        this.#params.mouseWheel.value = this.#mouseWheel;
+        this.#params.mouseDelta.value = this.#mouseDelta;
         await this.read();
     }
     async read() {

--- a/src/points.js
+++ b/src/points.js
@@ -279,8 +279,9 @@ class Points {
         this.#mouseNormalized[1] = this.#mouse[1] / this.#screen[1];
         this.#mouseNormalized[1] = (this.#mouseNormalized[1] * - 1) - -1; // flip and move up
 
-        this.#params.mouse.value = this.#mouse;
-        this.#params._mouse_normalized.value = this.#mouseNormalized;
+        const { mouse, _mouse_normalized } = this.#params
+        mouse.value = this.#mouse;
+        _mouse_normalized.value = this.#mouseNormalized;
     }
 
     /**
@@ -2569,9 +2570,10 @@ class Points {
         this.#time = this.#clock.time;
         this.#epoch = +new Date() / 1000;
 
-        this.#params.delta.value = this.#delta;
-        this.#params.time.value = this.#time;
-        this.#params.epoch.value = this.#epoch;
+        const { delta, time, epoch } = this.#params;
+        delta.value = this.#delta;
+        time.value = this.#time;
+        epoch.value = this.#epoch;
         //--------------------------------------------
         this.#writeParametersUniforms();
         this.#writeStorages();
@@ -2773,9 +2775,10 @@ class Points {
         this.#mouseDelta[0] = 0;
         this.#mouseDelta[1] = 0;
 
-        this.#params.mouseClick.value = this.#mouseClick;
-        this.#params.mouseWheel.value = this.#mouseWheel;
-        this.#params.mouseDelta.value = this.#mouseDelta;
+        const {mouseClick, mouseWheel, mouseDelta} = this.#params;
+        mouseClick.value = this.#mouseClick;
+        mouseWheel.value = this.#mouseWheel;
+        mouseDelta.value = this.#mouseDelta;
         await this.read();
     }
     async read() {
@@ -2954,6 +2957,31 @@ class Points {
     set scaleMode(val) {
         this.#scaleMode = +val;
         this.#setRatio();
+    }
+
+    /**
+     * Get the list of added uniforms, same as {@link uniforms}
+     * @example
+     *
+     * points.setUniform('myuniform', 10);
+     *
+     * // later
+     * points.params.myuniform.value = 12;
+     */
+    get params() {
+        return this.#params;
+    }
+    /**
+     * Get the list of added uniforms, same as {@link params}
+     * @example
+     *
+     * points.setUniform('myuniform', 10);
+     *
+     * // later
+     * points.uniforms.myuniform.value = 12;
+     */
+    get uniforms() {
+        return this.#params;
     }
 
     /**


### PR DESCRIPTION
- Solves #277 
- The only benefit from this is to avoid the call of `setUniform` inside the `#frame` method, so avoiding unnecessary validation and just updating the value.
- The user can technically use `points.params.MYUNIFORM` (or `points.uniforms`) to get the uniform created with `setUniform` to update the value directly, but it's not recommended how, so I haven't updated all the demos for this yet because I think this is better to make along with #275 and return a proper `Uniform` class instance, which doesn't exist yet.