### PR TITLE
270 setstorage   array without size throws error but it doesnt say why

### DIFF
--- a/examples/glb2/index.js
+++ b/examples/glb2/index.js
@@ -90,7 +90,7 @@ const base = {
 
         const dropdownItems = { /*'Vertex': 0,*/ 'Texture': 1, 'Shader': 2 };
 
-        uniforms.color_mode = options.mode;
+        uniforms.color_mode = +options.mode;
         folder.add(options, 'mode', dropdownItems).name('Colors').onChange(value => {
             console.log(value);
             uniforms.color_mode = +value;

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -39,8 +39,6 @@ class Storage {
         this.#stream = stream;
         this.#updated = updated;
         this.#size = size;
-        console.log(size);
-
 
         Object.seal(this);
     }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -331,6 +331,9 @@ class Storage {
     }
 
     #validateType(value) {
+        if (!value) {
+            return;
+        }
         if (typeof value !== 'string') {
             throw `Storage type '${value}' must be a String.`;
         }
@@ -341,7 +344,7 @@ class Storage {
             }
             const regex = /,\s*(\d+)\s*>/
             const match = value.match(regex);
-            if(!match){
+            if (!match) {
                 throw `Storage type '${value}' size must be an Number.`
             }
         }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -1,4 +1,4 @@
-import { getWGSLType } from './data-size.js'
+import { getWGSLType, isArray } from './data-size.js'
 
 /**
  * Storage is a container for storage buffer related data and actions.
@@ -39,6 +39,8 @@ class Storage {
         this.#stream = stream;
         this.#updated = updated;
         this.#size = size;
+        console.log(size);
+
 
         Object.seal(this);
     }
@@ -329,7 +331,20 @@ class Storage {
     }
 
     #validateType(value) {
-
+        if (typeof value !== 'string') {
+            throw `Storage type '${value}' must be a String.`;
+        }
+        const isValueArray = isArray(value);
+        if (isValueArray) {
+            if (!value.includes(',')) {
+                throw `The type '${value}' requires a size, e.g.: array<T, N>`
+            }
+            const regex = /,\s*(\d+)\s*>/
+            const match = value.match(regex);
+            if(!match){
+                throw `Storage type '${value}' size must be an Number.`
+            }
+        }
     }
 
     // allows for things like:

--- a/tests/storages/main.js
+++ b/tests/storages/main.js
@@ -269,4 +269,22 @@ QUnit.module('Storages', hooks => {
         }, 'Should fail if new storage uses existing name')
     })
 
+    QUnit.test('If type is array, should have size', assert => {
+        assert.throws(() => {
+            storages.testTypeSize.setType('array<f32>');
+        }, 'Should fail if array has no size')
+    })
+
+    QUnit.test('If type is array, should have size and size is a number', assert => {
+        assert.throws(() => {
+            storages.testTypeSize.setType('array<f32, q>');
+        }, 'Should fail if array size is not a number')
+    })
+
+    QUnit.test('Type definition should be a string', assert => {
+        assert.throws(() => {
+            storages.testNoStringType.setType({});
+        }, 'Should fail if type is no string')
+    })
+
 })


### PR DESCRIPTION
- setStorage now throws errors if the array type has no size as number
- also works with the new way to save storages (e.g. storages.myStorage.setType('array<T,N>'))