### PR TITLE
Center image in scale example

### DIFF
--- a/examples/screen_scale_1/frag.js
+++ b/examples/screen_scale_1/frag.js
@@ -58,7 +58,8 @@ fn main(in: FragmentIn) -> @location(0) vec4f {
 
     let dims = vec2f(textureDimensions(imgTexture)) / params.screen.yy;
     let dimsh = dims * .5;
-    let imgColor = texture(imgTexture, imageSampler, in.uvr - center + dimsh, true);
+    let imgColor = texture(imgTexture, imageSampler, in.uvr - center + dimsh, true)
+        * params.showImage;
 
     return layer(rectColor + lineColor + circleTopRightColor +
         circleBottomRightColor + circleBottomLeftColor + circleTopLeftColor,

--- a/examples/screen_scale_1/frag.js
+++ b/examples/screen_scale_1/frag.js
@@ -1,3 +1,5 @@
+import { layer } from "points/color";
+import { texture } from "points/image";
 import { sdfCircle, sdfLine, sdfRect, sdfSegment } from "points/sdf";
 
 const frag = /*wgsl*/`
@@ -6,6 +8,8 @@ ${sdfRect}
 ${sdfCircle}
 ${sdfLine}
 ${sdfSegment}
+${texture}
+${layer}
 
 const CIRCLERADIUS = .06;
 
@@ -45,7 +49,21 @@ fn main(in: FragmentIn) -> @location(0) vec4f {
 
     let lineColor = vec4f(line);
 
-    return rectColor + lineColor + circleTopRightColor + circleBottomRightColor + circleBottomLeftColor + circleTopLeftColor;
+    //-----
+    // note: I don't fully understand why to center the image is required to use
+    // params.screen.yy (mainly for COVER) but it works
+    // my guess is that because the ratio swaps in COVER, you can't use
+    //  params.screen * in.ratio
+    // because it would work in one (portrait), but not in the other (landscape)
+
+    let dims = vec2f(textureDimensions(imgTexture)) / params.screen.yy;
+    let dimsh = dims * .5;
+    let imgColor = texture(imgTexture, imageSampler, in.uvr - center + dimsh, true);
+
+    return layer(rectColor + lineColor + circleTopRightColor +
+        circleBottomRightColor + circleBottomLeftColor + circleTopLeftColor,
+        imgColor
+    );
 }
 `;
 

--- a/examples/screen_scale_1/index.js
+++ b/examples/screen_scale_1/index.js
@@ -10,6 +10,10 @@ const dropdown = {
     'HEIGHT': ScaleMode.HEIGHT
 };
 
+const options = {
+    showImage: false
+}
+
 const base = {
     vert,
     compute,
@@ -26,6 +30,10 @@ const base = {
         folder.add({ default: ScaleMode.HEIGHT }, 'default', dropdown)
             .onChange(value => points.scaleMode = value)
             .name('ScaleMode');
+
+        folder.add(options, 'showImage').name('showImage')
+            .onChange(value => points.uniforms.showImage = +value );
+        points.uniforms.showImage = options.showImage;
 
         folder.open();
     },

--- a/examples/screen_scale_1/index.js
+++ b/examples/screen_scale_1/index.js
@@ -20,6 +20,9 @@ const base = {
     init: async (points, folder) => {
         points.scaleMode = ScaleMode.HEIGHT;
 
+        points.setSampler('imageSampler', null);
+        await points.setTextureImage('imgTexture', './../../img/house_512x512.jpg');
+
         folder.add({ default: ScaleMode.HEIGHT }, 'default', dropdown)
             .onChange(value => points.scaleMode = value)
             .name('ScaleMode');


### PR DESCRIPTION
Center an image in different `ScaleMode`s doesn't work exactly as expected.

Updated the demo with a centered image that works in all modes. 