### PR TITLE
290 addeventlistener storage limit reached

### DIFF
--- a/docs/retrieve_data_from_the_shaders.md
+++ b/docs/retrieve_data_from_the_shaders.md
@@ -49,7 +49,7 @@ struct Event {
 }
 ```
 
-To actully fire an event you have to do as follows:
+To actually fire an event you have to do as follows:
 
 ```rust
 right_blink.data[0] = 2; // some data

--- a/docs/retrieve_data_from_the_shaders.md
+++ b/docs/retrieve_data_from_the_shaders.md
@@ -20,24 +20,25 @@ console.log(result);
 
 ## Events - addEventListener
 
-An event is an asynchronous message that can be send from the WGSL shaders to the JavaScript code. It works in a very similar way as to listen for a click in JavaScript or a screen resize, you call a `addEventListener`, but the parameters and its use change a bit. In the code below, the first parameter is the name of the event you , the event is fired by **you**, so this name currently has no predefined names like 'click', or 'mouse over', you have to define them and dispatch them.
+An event is an asynchronous message that can be send from the WGSL shaders to the JavaScript code. It works in a very similar way as to listen for a click in JavaScript or a screen resize, you call a `addEventListener`, but the parameters and its use change a bit. In the code below, the first parameter is the name of the event, the event is fired by **you**, so this name currently has no predefined names like 'click', or 'mouse over', you have to define them and dispatch them.
 
-The second parameter is the data (if any) that you will send from the WGSL shaders, this data is returnes as an array, so you have to acces each item by its index.
+The second parameter is the data (if any) that you will send from the WGSL shaders, this data is returned as an array, so you have to access each item by its index.
 
-The last parameter is the amount of items in this array you are expecting. All items are `f32`.
+The default amount of items the data can hold is 4. All items are `f32`.
 
 ```js
 // as in examples\events1\index.js
 points.addEventListener(
-    'right_blink', // name of the event (and name of a storage)
+    'right_blink', // name of the event
     data => { // data returned after the event and callback
-        console.log('---- Right Circle');
-    },
-    4 // size of the data to return
+        console.log('---- Right Circle', data);
+        const [a, b, c, d] = data;
+        output.text += `\nRight: ${a} ${b} ${c} ${d}`;
+    }
 );
 ```
 
-To fire an event you first need to declare the listener. The name used in the listener is also used as storage buffer that you can manipulate to dispatch the event.
+To fire an event you first need to declare the listener as shown above. The name used in the listener is also used as struct attribute in a Storage buffer that you can manipulate to dispatch the event. The storage will be added automatically to your shaders with the name `events`.
 
 The event has the following structure:
 
@@ -45,16 +46,18 @@ The event has the following structure:
 // as in src\core\defaultStructs.js
 struct Event {
     updated: u32,
-    data: array<f32>
+    data: array<f32, 4>
 }
 ```
 
 To actually fire an event you have to do as follows:
 
 ```rust
-right_blink.data[0] = 2; // some data
-right_blink.data[1] = 2; // some data
-right_blink.updated = 1; // update this property to something diff than `0`
+events.right_blink.data[0] = 10; // some data
+events.right_blink.data[1] = 20; // some data
+events.right_blink.data[2] = 30; // some data
+events.right_blink.data[3] = 40; // some data
+events.right_blink.updated = 1; // update this property to something diff than `0`
 ```
 
 By just simply changing the value of `updated` to a non zero, the library knows this event has been updated, and will dispatch the event immediately in JavaScript, so the `console.log` will print the text in the JavaScript Console. `updated` will be set as zero in the next frame, and if not updated the library then knows it doesn't have to do anything.

--- a/examples/audio1/frag.js
+++ b/examples/audio1/frag.js
@@ -12,7 +12,7 @@ fn main(in: FragmentIn) -> @location(0) vec4f {
     let audioX = audio.data[u32(in.uvr.x * params.audioLength)] / 256;
 
     if(params.mouseClick == 1.){
-        click_event.updated = 1;
+        events.click_event.updated = 1;
         // other actions
         showMessage = 1.;
     }

--- a/examples/audio1/index.js
+++ b/examples/audio1/index.js
@@ -23,9 +23,7 @@ const base = {
             loop,
             false
         );
-        points.addEventListener('click_event', data => {
-            audio.play();
-        }, 4);
+        points.addEventListener('click_event', _ => audio.play());
 
 
         storages.showMessage.setShaderStage(FRAGMENT).setType('f32');

--- a/examples/audio2/frag.js
+++ b/examples/audio2/frag.js
@@ -19,7 +19,7 @@ const segmentNum = 4;
 fn main(in: FragmentIn) -> @location(0) vec4f {
 
     if(params.mouseClick == 1.){
-        click_event.updated = 1;
+        events.click_event.updated = 1;
         // other actions
         showMessage = 0.;
     }

--- a/examples/audio2/index.js
+++ b/examples/audio2/index.js
@@ -13,7 +13,7 @@ const base = {
      */
     init: async points => {
         const { storages } = points;
-        const {FRAGMENT} = GPUShaderStage;
+        const { FRAGMENT } = GPUShaderStage;
         let volume = 1;
         let loop = true;
         audio = points.setAudio(
@@ -24,9 +24,7 @@ const base = {
             false
         );
 
-        points.addEventListener('click_event', data => {
-            audio.play();
-        }, 4);
+        points.addEventListener('click_event', _ => audio.play());
 
         points.setSampler('imageSampler', null);
         points.setTexture2d('feedbackTexture', true);

--- a/examples/cubes1/cube_renderpass/compute.js
+++ b/examples/cubes1/cube_renderpass/compute.js
@@ -40,9 +40,9 @@ fn main(in: ComputeIn) {
 
     let flipTexture = vec3(1.,-1.,1);
     let flipTextureCoordinates = vec3(-.5,.5,1);
-    // if(f32(index)>log_data[0]){
-    //     log_data[0] = f32(index);
-    //     log.updated = 1;
+    // if(f32(index) > events.log.data[0]){
+    //     events.log.data[0] = f32(index);
+    //     events.log.updated = 1;
     // }
     if(particle.init == 0){
         rand_seed.x = f32(index);

--- a/examples/cubes1/index.js
+++ b/examples/cubes1/index.js
@@ -82,7 +82,7 @@ const base = {
 
         points.addEventListener('log', data => {
             console.log('Array Max:', data[0] + 1);
-        }, 1)
+        })
 
         points.setCameraPerspective('camera');
 

--- a/examples/data1/compute.js
+++ b/examples/data1/compute.js
@@ -27,8 +27,8 @@ fn main(in: ComputeIn) {
 
     let index = resultCell.y + resultCell.x * u32(secondMatrix.size.y);
     resultMatrix.numbers[index] = result;
-    result_test_data[index] = result;
-    result_test.updated = 1;
+    events.result_test.data[index] = result;
+    events.result_test.updated = 1;
 
 }
 `;

--- a/examples/data1/index.js
+++ b/examples/data1/index.js
@@ -42,7 +42,7 @@ const data1 = {
         points.addEventListener('result_test', data => {
             // const [a, b, c, d] = data;
             // console.log('---- result', a, b, c, d);
-        }, 4);
+        });
 
     },
     update: async points => {

--- a/examples/events1/frag.js
+++ b/examples/events1/frag.js
@@ -17,14 +17,14 @@ fn main(in: FragmentIn) -> @location(0) vec4f {
     // < ------------ TWO PULSATING CIRCLES
 
     if(f0 >= .9999){
-        left_blink_data[0] = 11.;
-        left_blink_data[1] = 22.;
+        left_blink.data[0] = 11.;
+        left_blink.data[1] = 22.;
         left_blink.updated = 1u;
     }
 
     if(f1 >= .9999){
-        right_blink_data[0] = 33.;
-        right_blink_data[1] = params.time;
+        right_blink.data[0] = 33.;
+        right_blink.data[1] = params.time;
         right_blink.updated = 1u;
     }
 

--- a/examples/events1/frag.js
+++ b/examples/events1/frag.js
@@ -17,15 +17,15 @@ fn main(in: FragmentIn) -> @location(0) vec4f {
     // < ------------ TWO PULSATING CIRCLES
 
     if(f0 >= .9999){
-        left_blink.data[0] = 11.;
-        left_blink.data[1] = 22.;
-        left_blink.updated = 1u;
+        events.left_blink.data[0] = 11.;
+        events.left_blink.data[1] = 22.;
+        events.left_blink.updated = 1u;
     }
 
     if(f1 >= .9999){
-        right_blink.data[0] = 33.;
-        right_blink.data[1] = params.time;
-        right_blink.updated = 1u;
+        events.right_blink.data[0] = 33.;
+        events.right_blink.data[1] = params.time;
+        events.right_blink.updated = 1u;
     }
 
     let circleValue1 = sdfCircle(vec2f(.2,.5) * in.ratio, .01 + f0 * .09, 0., in.uvr);

--- a/examples/events1/index.js
+++ b/examples/events1/index.js
@@ -20,7 +20,7 @@ const base = {
             console.log('---- Left Circle', data);
             const [a, b] = data;
             output.text += `\nLeft: ${a} ${b}`;
-        }, 2);
+        });
 
         points.addEventListener(
             'right_blink', // name of the event (and name of a storage)
@@ -28,8 +28,7 @@ const base = {
                 console.log('---- Right Circle', data);
                 const [a, b, c, d] = data;
                 output.text += `\nRight: ${a} ${b} ${c} ${d}`;
-            },
-            4 // size of the data to return
+            }
         );
     },
     /**

--- a/examples/glb2/glb_renderpass/compute.js
+++ b/examples/glb2/glb_renderpass/compute.js
@@ -33,9 +33,9 @@ fn main(in: ComputeIn) {
 
     let particle = &particles[index];
 
-    // if(f32(index) > logger.data[0]){
-    //     logger.data[0] = f32(index);
-    //     logger.updated = 1;
+    // if(f32(index) > events.logger.data[0]){
+    //     events.logger.data[0] = f32(index);
+    //     events.logger.updated = 1;
     // }
     if(particle.init == 0){
         rand_seed.x = f32(index);

--- a/examples/glb2/glb_renderpass/compute.js
+++ b/examples/glb2/glb_renderpass/compute.js
@@ -33,9 +33,9 @@ fn main(in: ComputeIn) {
 
     let particle = &particles[index];
 
-    // if(f32(index)>log_data[0]){
-    //     log_data[0] = f32(index);
-    //     log.updated = 1;
+    // if(f32(index) > logger.data[0]){
+    //     logger.data[0] = f32(index);
+    //     logger.updated = 1;
     // }
     if(particle.init == 0){
         rand_seed.x = f32(index);

--- a/examples/glb2/index.js
+++ b/examples/glb2/index.js
@@ -118,7 +118,7 @@ const base = {
 
         points.addEventListener('logger', data => {
             console.log(data[0]);
-        }, 4)
+        })
 
         points.setCameraPerspective('camera');
 

--- a/examples/particles1/index.js
+++ b/examples/particles1/index.js
@@ -49,7 +49,7 @@ const base = {
             const [a, b, c, d] = data;
             // console.clear();
             console.log({ a, c }, { b, d });
-        }, 4);
+        });
 
 
         uniforms.maxLife = options.maxLife;

--- a/examples/particles1/r0/compute.js
+++ b/examples/particles1/r0/compute.js
@@ -70,10 +70,10 @@ fn main(in: ComputeIn) {
     textureStore(writeTexture, particle_position_i, (*particle).color);
 
     // debug
-    // log_data[0] = (*particle).position.x;
-    // log_data[1] = (*particle).position.y;
-    // log_data[2] = f32(any(particle_position >= SIZE));
-    // log_data[3] = f32(any(particle_position <= vec2f()));
+    // log.data[0] = (*particle).position.x;
+    // log.data[1] = (*particle).position.y;
+    // log.data[2] = f32(any(particle_position >= SIZE));
+    // log.data[3] = f32(any(particle_position <= vec2f()));
     // log.updated = 1;
 }
 `;

--- a/examples/particles1/r0/compute.js
+++ b/examples/particles1/r0/compute.js
@@ -70,11 +70,11 @@ fn main(in: ComputeIn) {
     textureStore(writeTexture, particle_position_i, (*particle).color);
 
     // debug
-    // log.data[0] = (*particle).position.x;
-    // log.data[1] = (*particle).position.y;
-    // log.data[2] = f32(any(particle_position >= SIZE));
-    // log.data[3] = f32(any(particle_position <= vec2f()));
-    // log.updated = 1;
+    // events.log.data[0] = (*particle).position.x;
+    // events.log.data[1] = (*particle).position.y;
+    // events.log.data[2] = f32(any(particle_position >= SIZE));
+    // events.log.data[3] = f32(any(particle_position <= vec2f()));
+    // events.log.updated = 1;
 }
 `;
 

--- a/src/core/defaultStructs.js
+++ b/src/core/defaultStructs.js
@@ -53,7 +53,7 @@ struct Sound {
 
 struct Event {
     updated: u32,
-    // data: array<f32>
+    data: array<f32>
 }
 `;
 

--- a/src/core/defaultStructs.js
+++ b/src/core/defaultStructs.js
@@ -53,7 +53,7 @@ struct Sound {
 
 struct Event {
     updated: u32,
-    data: array<f32>
+    data: array<f32, 4>
 }
 `;
 

--- a/src/points.js
+++ b/src/points.js
@@ -1260,7 +1260,6 @@ class Points {
      * Listens for an event dispatched from WGSL code
      * @param {String} name Number that represents an event Id
      * @param {Function} callback function to be called when the event occurs
-     * @param {Number} structSize size of the array data to be returned
      *
      * @example
      * // js
@@ -1268,15 +1267,15 @@ class Points {
      * // and a data variable that starts with the name
      * points.addEventListener('click_event', data => {
      *     // response action in JS
-     *      const [a, b, c, d] = data;
+     *      const [a, b, c, d] = data; // data will have 4 items by default
      *      console.log({a, b, c, d});
-     * }, 4); // data will have 4 items
+     * });
      *
      * // wgsl string
      *  if(params.mouseClick == 1.){
      *      // we update our event response data with something we need
      *      // on the js side
-     *      // click_event_data has 4 items to fill
+     *      // click_event.data has 4 items to fill
      *      click_event_data[0] = params.time;
      *      // Same name of the Event
      *      // we fire the event with a 1
@@ -1285,18 +1284,8 @@ class Points {
      *  }
      *
      */
-    addEventListener(name, callback, structSize = 1) {
+    addEventListener(name, callback) {
         const { COMPUTE, FRAGMENT } = GPUShaderStage;
-        // TODO: remove structSize
-        // this extra 1 is for the boolean flag in the Event struct
-
-        this.#storages.add(new Storage({
-            name,
-            type: 'Event',
-            readable: true,
-            shaderStage: COMPUTE | FRAGMENT,
-            value: Array(4 + structSize * 4).fill(0)
-        }));
 
         this.#events.set(this.#events_ids,
             {
@@ -1517,6 +1506,29 @@ class Points {
         dynamicStructParams += dynamicStructMesh;
         dynamicStructParams += dynamicStructCamera;
 
+        // start events: We add the events Storage. It will hold all the events
+        let dynamicStructEvents = '';
+        if (this.#events.size > 0) {
+
+            let structSizeEvents = 0;
+            for (const [key, event] of this.#events) {
+                console.log(key, event);
+                dynamicStructEvents += /*wgsl*/`${event.name}: Event, \n\t`;
+                structSizeEvents += 20; //(4 + 4 * 4)
+            }
+
+            dynamicStructEvents = /*wgsl*/`struct Events {\n\t${dynamicStructEvents}\n}\n`;
+
+            this.#storages.add(new Storage({
+                name: 'events',
+                type: 'Events',
+                readable: true,
+                shaderStage: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+                value: Array(structSizeEvents).fill(0)
+            }));
+        }
+        // end events
+
         const constantsVertex = this.#constants.stringOfNonOverrides(GPUShaderStage.VERTEX);
         const constantsCompute = this.#constants.stringOfNonOverrides(GPUShaderStage.COMPUTE);
         const constantsFragment = this.#constants.stringOfNonOverrides(GPUShaderStage.FRAGMENT);
@@ -1540,9 +1552,9 @@ class Points {
             dynamicGroupBindingsFragment = i + dynamicGroupBindingsFragment;
         })
 
-        renderPass.hasVertexShader && (colorsVertWGSL = dynamicGroupBindingsVertex + defaultStructs + defaultVertexBody + colorsVertWGSL);
-        renderPass.hasComputeShader && (colorsComputeWGSL = dynamicGroupBindingsCompute + defaultStructs + colorsComputeWGSL);
-        renderPass.hasFragmentShader && (colorsFragWGSL = dynamicGroupBindingsFragment + defaultStructs + colorsFragWGSL);
+        renderPass.hasVertexShader && (colorsVertWGSL = dynamicGroupBindingsVertex + defaultStructs + dynamicStructEvents + defaultVertexBody + colorsVertWGSL);
+        renderPass.hasComputeShader && (colorsComputeWGSL = dynamicGroupBindingsCompute + defaultStructs + dynamicStructEvents + colorsComputeWGSL);
+        renderPass.hasFragmentShader && (colorsFragWGSL = dynamicGroupBindingsFragment + defaultStructs + dynamicStructEvents + colorsFragWGSL);
 
         if (this.#debug) {
             console.groupCollapsed(`Render Pass ${index}: (${renderPass.name})`);
@@ -2785,20 +2797,27 @@ class Points {
         await this.read();
     }
     async read() {
+        if (this.#events.size === 0) {
+            return;
+        }
+
+        const eventRead = await this.readStorage('events');
         for (const [key, event] of this.#events) {
-            const { name } = event;
-            const eventRead = await this.readStorage(name);
-            if (eventRead) {
-                const id = eventRead[0];
-                if (id != 0) {
-                    const [a, ...b] = eventRead;
-                    event?.callback(b);
-                    const storageToUpdate = this.#storages.find(name);
-                    if (storageToUpdate) {
-                        const data = storageToUpdate.value;
-                        data[0] = 0;
-                        this.setStorage(name).setValue(data);
-                    }
+            const { id, name } = event;
+
+            const eventId = id * 5
+            const updated = eventRead[eventId]; // 5 is the length of each event data + id
+            if (updated != 0) {
+                const a = eventRead[eventId + 1];
+                const b = eventRead[eventId + 2];
+                const c = eventRead[eventId + 3];
+                const d = eventRead[eventId + 4];
+                event?.callback([a, b, c, d]);
+                const storageToUpdate = this.#storages.find('events');
+                if (storageToUpdate) {
+                    const data = storageToUpdate.value;
+                    data[id * 5] = 0;
+                    this.setStorage('events').setValue(data);
                 }
             }
         }

--- a/src/points.js
+++ b/src/points.js
@@ -2799,8 +2799,8 @@ class Points {
         if (this.#events.size === 0) {
             return;
         }
-
-        const eventRead = await this.readStorage('events');
+        const events = 'events';
+        const eventRead = await this.readStorage(events);
         for (const [key, event] of this.#events) {
             const { id } = event;
             const eventId = id * 5
@@ -2812,11 +2812,11 @@ class Points {
                 const c = eventRead[eventId + 3];
                 const d = eventRead[eventId + 4];
                 event?.callback([a, b, c, d]);
-                const storageToUpdate = this.#storages.find('events');
+                const storageToUpdate = this.#storages.find(events);
                 if (storageToUpdate) {
                     const data = storageToUpdate.value;
                     data[id * 5] = 0;
-                    this.setStorage('events').setValue(data);
+                    this.setStorage(events).setValue(data);
                 }
             }
         }

--- a/src/points.js
+++ b/src/points.js
@@ -1295,14 +1295,7 @@ class Points {
             type: 'Event',
             readable: true,
             shaderStage: COMPUTE | FRAGMENT,
-            value: Array(4).fill(0)
-        }));
-
-        this.#storages.add(new Storage({
-            name: `${name}_data`,
-            type: `array<f32, ${structSize}>`,
-            readable: true,
-            shaderStage: COMPUTE | FRAGMENT
+            value: Array(4 + structSize * 4).fill(0)
         }));
 
         this.#events.set(this.#events_ids,
@@ -2798,8 +2791,8 @@ class Points {
             if (eventRead) {
                 const id = eventRead[0];
                 if (id != 0) {
-                    const dataRead = await this.readStorage(`${name}_data`)
-                    event?.callback(dataRead);
+                    const [a, ...b] = eventRead;
+                    event?.callback(b);
                     const storageToUpdate = this.#storages.find(name);
                     if (storageToUpdate) {
                         const data = storageToUpdate.value;

--- a/src/points.js
+++ b/src/points.js
@@ -1512,7 +1512,6 @@ class Points {
 
             let structSizeEvents = 0;
             for (const [key, event] of this.#events) {
-                console.log(key, event);
                 dynamicStructEvents += /*wgsl*/`${event.name}: Event, \n\t`;
                 structSizeEvents += 20; //(4 + 4 * 4)
             }
@@ -2803,11 +2802,11 @@ class Points {
 
         const eventRead = await this.readStorage('events');
         for (const [key, event] of this.#events) {
-            const { id, name } = event;
-
+            const { id } = event;
             const eventId = id * 5
             const updated = eventRead[eventId]; // 5 is the length of each event data + id
-            if (updated != 0) {
+
+            if (!!updated) {
                 const a = eventRead[eventId + 1];
                 const b = eventRead[eventId + 2];
                 const c = eventRead[eventId + 3];


### PR DESCRIPTION
- Single Storage buffer to handle all the events internally instead of one per event created with `addEventListener`
- Restored old functionality of `event.data` and `event.updated` which was fixed in another branch.
- All events from the wgsl side will be enclosed in a Events struct and a events storage buffer reference, so if the user adds a 'click' event, on wgsl they can access it via `events.click`