### PR TITLE
Fix to uniforms and storages u32

### DIFF
--- a/examples/glb3/structs.js
+++ b/examples/glb3/structs.js
@@ -9,7 +9,7 @@ struct FragmentCustom {
     @location(4) mouse: vec2f,
     @location(5) normal: vec3f,
     @location(6) world: vec3f,
-    @interpolate(flat) @location(7) id: u32
+    @interpolate(flat) @location(7) id: f32
 }
 
 `;

--- a/examples/mandelbrot1/index.js
+++ b/examples/mandelbrot1/index.js
@@ -16,7 +16,6 @@ const base = {
         const { uniforms, storages } = points;
         const { FRAGMENT } = GPUShaderStage
         points.scaleMode = ScaleMode.FIT;
-        uniforms.scale = options.scale;
         uniforms.numIterations = options.numIterations;
 
         storages.variables.setType('Variable').setShaderStage(FRAGMENT);

--- a/src/RenderPass.js
+++ b/src/RenderPass.js
@@ -1860,6 +1860,7 @@ class RenderPass extends EventTarget {
             vertexArray[offset++] = normals[idx3 + 1];
             vertexArray[offset++] = normals[idx3 + 2];
 
+            // --- id ---
             vertexArray[offset++] = meshCounter;
 
             const bary = BARYCENTRICS[i % 3];

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -40,7 +40,7 @@ class Storage {
         this.#value = value;
 
         this.#stream = stream;
-        this.#updated = updated;
+        this.#updated = updated || !!value; // if a value is set in constructor it should be updated
         this.#size = size;
 
         Object.seal(this);
@@ -199,14 +199,7 @@ class Storage {
     }
 
     get value() {
-        let value = this.#value;
-        // Internally, what Points use to create the buffer is a Uint8Array
-        // TODO: maybe move to POINTS?
-        if (value && !Array.isArray(value) && value.constructor !== Uint8Array) {
-            value = new Uint8Array([value]);
-        }
-
-        return value;
+        return this.#value;
     }
 
     /**

--- a/src/Storages.js
+++ b/src/Storages.js
@@ -36,7 +36,7 @@ export default class Storages {
                     return value;
                 }
                 // If Storage does not exist we create it.
-                const storage = new Storage({ name: prop, value: 0 });
+                const storage = new Storage({ name: prop });
                 target.list.push(storage);
                 Reflect.set(target, prop, storage, target);
                 return storage;

--- a/src/core/ArrayBufferWriter.js
+++ b/src/core/ArrayBufferWriter.js
@@ -1,0 +1,128 @@
+import { getArrayTypeAndAmount } from "../data-size.js";
+
+class ArrayBufferWriter {
+    #buffer
+    #view
+    #offset = 0
+
+    #indexesAdded = [];
+
+    #vecs = {
+        'vec4f': 'f32',
+        'vec4<f32>': 'f32',
+
+        'vec4u': 'u32',
+        'vec4<u32>': 'u32',
+
+        'vec4i': 'i32',
+        'vec4<i32>': 'i32',
+
+        'vec3f': 'f32',
+        'vec3<f32>': 'f32',
+
+        'vec3u': 'u32',
+        'vec3<u32>': 'u32',
+
+        'vec3i': 'i32',
+        'vec3<i32>': 'i32',
+
+        'vec2f': 'f32',
+        'vec2<f32>': 'f32',
+
+        'vec2u': 'u32',
+        'vec2<u32>': 'u32',
+
+        'vec2i': 'i32',
+        'vec2<i32>': 'i32',
+    }
+
+    constructor(numItems) {
+        this.#buffer = new ArrayBuffer(numItems * 4);
+        this.#view = new DataView(this.#buffer);
+    }
+
+    get offset() {
+        return this.#offset
+    }
+
+    get buffer() {
+        return this.#buffer
+    }
+
+    setN32(value, type) {
+        this.#indexesAdded.push(this.#offset);
+
+        switch (type) {
+            default:
+            case 'f32':
+                this.#view.setFloat32(this.#offset, value, true);
+                break;
+            case 'u32':
+                this.#view.setUint32(this.#offset, value, true);
+                break;
+            case 'i32':
+                this.#view.setInt32(this.#offset, value, true);
+                break;
+        }
+        this.#offset += Float32Array.BYTES_PER_ELEMENT;
+    }
+
+    set(value, type) {
+        const isArray = Array.isArray(value);
+        if (isArray) {
+            const isWGSLArray = type.includes('array');
+            if (isWGSLArray) {
+                type = getArrayTypeAndAmount(type)[0].type;
+            }
+            if (type.includes('vec')) {
+                type = this.#vecs[type];
+            }
+
+            value.forEach(v => this.setN32(v, type));
+            return;
+        }
+
+        this.setN32(value, type);
+    }
+
+    hexDump() {
+        const byteView = new Uint8Array(this.#buffer);
+
+        const hexRows = Array.from(byteView).map((b, i) => {
+            return {
+                offset: `0x${i.toString(16).padStart(2, '0').toUpperCase()}`,
+                byte: b,
+                hex: `0x${b.toString(16).padStart(2, '0').toUpperCase()}`,
+                binary: b.toString(2).padStart(8, '0')
+            };
+        });
+
+        console.table(hexRows);
+    }
+
+    dump() {
+        const view = this.#view;
+        const results = [];
+
+        for (let i = 0; i < view.byteLength; i++) {
+            const isInList = this.#indexesAdded.includes(i / 4);
+            if (!isInList) {
+                continue;
+            }
+
+            const row = { byteOffset: i, uint8: view.getUint8(i) };
+
+            if (i <= view.byteLength - Int32Array.BYTES_PER_ELEMENT) {
+                row.int32_LE = view.getInt32(i, true);
+                row.uint32_LE = view.getUint32(i, true);
+                row.float32_LE = +view.getFloat32(i, true).toFixed(2);
+            }
+
+            results.push(row);
+        }
+
+        console.table(results);
+    }
+}
+
+export default ArrayBufferWriter;

--- a/src/core/defaultStructs.js
+++ b/src/core/defaultStructs.js
@@ -24,7 +24,7 @@ struct VertexIn {
     @location(1) color:vec4f,
     @location(2) uv:vec2f,
     @location(3) normal:vec3f,
-    @location(4) id:u32,       // mesh id
+    @location(4) id:f32,       // mesh id
     @location(5) barycentrics: vec3f,
     @location(6) joint: vec4u,
     @location(7) weight:vec4f,
@@ -40,7 +40,7 @@ struct FragmentIn {
     @location(3) uvr: vec2f,    // uv with aspect ratio corrected
     @location(4) mouse: vec2f,
     @location(5) normal: vec3f,
-    @interpolate(flat) @location(6) id: u32, // mesh or instance id
+    @interpolate(flat) @location(6) id: f32, // mesh or instance id
     @location(7) barycentrics: vec3f,
     @location(8) world: vec3f,
 }

--- a/src/points.js
+++ b/src/points.js
@@ -22,6 +22,7 @@ import Storages from './Storages.js';
 import Constants from './Constants.js';
 import RenderPass, { PrimitiveTopology, LoadOp, CullMode, FrontFace } from './RenderPass.js';
 import RenderPasses from './RenderPasses.js';
+import ArrayBufferWriter from './core/ArrayBufferWriter.js';
 
 /**
  * Main class Points, this is the entry point of an application with this library.
@@ -1737,7 +1738,7 @@ class Points {
         // TODO: this should be inside RenderPass, to not call vertexArray outside
         this.#renderPasses.forEach((r, i) => {
             r.init?.(this);
-            r.meshes.forEach(mesh => this.#setMeshUniform(mesh.name, mesh.id, 'u32'));
+            r.meshes.forEach(mesh => this.#setMeshUniform(mesh.name, mesh.id, 'f32'));
 
             this.createScreen(r);
             r.vertexBufferInfo = new VertexBufferInfo(r.vertexArray);
@@ -1850,7 +1851,7 @@ class Points {
         this.#device.queue.writeBuffer(
             buffer,
             0,
-            new Float32Array(values)
+            values
         );
     }
 
@@ -1861,25 +1862,31 @@ class Points {
      * @returns {{values:Float32Array, paramsDataSize:Object}}
      */
     #createUniformValues(uniformsArray, structName = 'Params') {
-        const paramsDataSize = this.#dataSize.get(structName)
+        const paramsDataSize = this.#dataSize.get(structName);
         const paddings = paramsDataSize.paddings;
-        // we check the paddings list and add 0's to just the ones that need it
-        const arrayValues = uniformsArray.map(u => {
-            const v = u.serialize(); // clone the item to not modify the original
+
+        const typedValues = uniformsArray.map(u => {
+            const v = u.serialize();
+
+            if (v.value.constructor !== Array) {
+                v.value = [v.value];
+            }
 
             const padding = paddings[v.name] / 4;
             if (padding) {
-                if (v.value.constructor !== Array) {
-                    v.value = [v.value];
-                }
                 for (let i = 0; i < padding; i++) {
                     v.value.push(0);
                 }
             }
-            return v.value;
+
+            return v.value.map(val => ({ value: val, type: v.type }));
+
         }).flat(1);
 
-        return { values: new Float32Array(arrayValues), paramsDataSize };
+        const writer = new ArrayBufferWriter(typedValues.length);
+        typedValues.forEach(t => writer.set(t.value, t.type));
+
+        return { values: writer.buffer, paramsDataSize };
     }
 
     #createParametersUniforms() {
@@ -1923,9 +1930,18 @@ class Points {
         this.#storages.list.forEach(storageItem => {
             // since audio is something constant
             // the stream flag allows to keep this write open
-            const { updated, stream } = storageItem;
+            const { updated, stream, type } = storageItem;
             if (storageItem.mapped && (updated || stream)) {
-                const values = new Float32Array(storageItem.value);
+                let value = storageItem.value;
+
+                // this is only for the audio read which is `Uint8Array`
+                if (value.constructor.name === 'Uint8Array') {
+                    value = Array.from(value);
+                }
+
+                const writer = new ArrayBufferWriter(value.length || 1);
+                writer.set(value, type)
+                const values = writer.buffer;
                 this.#writeBuffer(storageItem.buffer, values);
                 if (!stream) {
                     storageItem.updated = false;
@@ -1944,9 +1960,9 @@ class Points {
         //--------------------------------------------
         this.#storages.list.forEach(storageItem => {
             let usage = GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST;
-            const { readable, name, size, mapped } = storageItem;
+            const { readable, name, size, mapped, value, type } = storageItem;
             if (readable) {
-                const readSize = mapped ? storageItem.value.length : size;
+                const readSize = mapped ? value.length : size;
 
                 storageItem.bufferRead = this.#device.createBuffer({
                     label: name,
@@ -1958,7 +1974,9 @@ class Points {
             }
 
             if (mapped) {
-                const values = new Float32Array(storageItem.value);
+                const writer = new ArrayBufferWriter(value.length || 1);
+                writer.set(value, type)
+                const values = writer.buffer;
                 storageItem.buffer = this.#createAndMapBuffer(values, usage, true, size);
             } else {
                 storageItem.buffer = this.#createBuffer(size, usage);
@@ -2204,7 +2222,7 @@ class Points {
                                         // id -> meshCounter
                                         shaderLocation: 4,
                                         offset: renderPass.vertexBufferInfo.idOffset,
-                                        format: 'uint32',
+                                        format: 'float32',
                                     },
                                     {
                                         // barycentrics

--- a/tests/storages/main.js
+++ b/tests/storages/main.js
@@ -112,7 +112,7 @@ QUnit.module('Storages', hooks => {
     QUnit.test('Assigning value without type, sets the type automatically', assert => {
         const type = 'u32';
         storages.MYSTORAGE = 10;
-        assert.equal(storages.MYCONST.type, type, 'It should have a type assigned');
+        assert.equal(storages.MYSTORAGE.type, type, 'It should have a type assigned');
     })
 
     QUnit.test('Assigning float should set type to f32', assert => {


### PR DESCRIPTION
Basically, there was an error in uniforms and storages that made u32 and i32 to have a wrong representation internally since everything was converted to Float32Array; this was an original core decision of the library to avoid complications in the beginning, so basically making every number an f32 to make things easy. The libraty technically supports u32 and i32 for a while, and apart from maybe a demo, no issues were recorded in other demos, but internally the Int numbers were f32s and the values exploded in size because of the misinterpretation.

Fix removes a few internal assumptions live default converting fo Float32Array in a few places.

Now it converts appropriately based on the type defined by user on the JS side.

This solves #315 